### PR TITLE
Replace CELERY_WORKER_EXTRA_ARGS maxtasksperchild with max-tasks-per-child

### DIFF
--- a/docs/source/administrator/_demo_camcops_config.ini
+++ b/docs/source/administrator/_demo_camcops_config.ini
@@ -189,7 +189,7 @@ CELERY_BEAT_EXTRA_ARGS =
 CELERY_BEAT_SCHEDULE_DATABASE = /var/lock/camcops/camcops_celerybeat_schedule
 CELERY_BROKER_URL = amqp://
 CELERY_WORKER_EXTRA_ARGS =
-    --maxtasksperchild=1000
+    --max-tasks-per-child=1000
 CELERY_EXPORT_TASK_RATE_LIMIT = 100/m
 EXPORT_LOCKDIR = /var/lock/camcops
 

--- a/docs/source/administrator/resource_usage.rst
+++ b/docs/source/administrator/resource_usage.rst
@@ -119,7 +119,7 @@ Celery. See:
 - https://docs.celeryproject.org/en/latest/userguide/workers.html#max-tasks-per-child-setting
 - possibly related: https://github.com/celery/celery/issues/4843 (2018)
 
-A solution: use ``--maxtasksperchild=20`` in the :ref:`CELERY_WORKER_EXTRA_ARGS
+A solution: use ``--max-tasks-per-child=20`` in the :ref:`CELERY_WORKER_EXTRA_ARGS
 <CELERY_WORKER_EXTRA_ARGS>` config parameter. This successfully caps memory
 usage at around 750 MiB for a one-worker container.
 

--- a/docs/source/administrator/server_config_file.rst
+++ b/docs/source/administrator/server_config_file.rst
@@ -1491,7 +1491,7 @@ An example to prevent the :ref:`Celery-related memory leak
 .. code-block:: ini
 
     CELERY_WORKER_EXTRA_ARGS =
-        --maxtasksperchild=20
+        --max-tasks-per-child=20
 
 
 CELERY_EXPORT_TASK_RATE_LIMIT

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3663,3 +3663,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
   Note: "E203 whitespace before ':'" errors should be suppressed. See
   https://github.com/psf/black/issues/315;
   https://black.readthedocs.io/en/stable/faq.html.
+
+- Change ``CELERY_WORKER_EXTRA_ARGS`` ``--maxtasksperchild`` to ``--max-tasks-per-child``
+  following removal of --maxtasksperchild in Celery 5.0.

--- a/server/camcops_server/cc_modules/cc_config.py
+++ b/server/camcops_server/cc_modules/cc_config.py
@@ -519,7 +519,7 @@ def get_demo_config(for_docker: bool = False) -> str:
 {ConfigParamExportGeneral.CELERY_BEAT_SCHEDULE_DATABASE} = {cd.CELERY_BEAT_SCHEDULE_DATABASE}
 {ConfigParamExportGeneral.CELERY_BROKER_URL} = {cd.CELERY_BROKER_URL}
 {ConfigParamExportGeneral.CELERY_WORKER_EXTRA_ARGS} =
-    --maxtasksperchild=1000
+    --max-tasks-per-child=1000
 {ConfigParamExportGeneral.CELERY_EXPORT_TASK_RATE_LIMIT} = 100/m
 {ConfigParamExportGeneral.EXPORT_LOCKDIR} = {cd.EXPORT_LOCKDIR}
 

--- a/server/camcops_server/cc_modules/cc_constants.py
+++ b/server/camcops_server/cc_modules/cc_constants.py
@@ -158,9 +158,7 @@ class DateFormat(object):
     ISO8601_DATE_ONLY = "%Y-%m-%d"  # e.g. 2013-07-24
     FHIR_DATE = "%Y-%m-%d"  # e.g. 2013-07-24
     # FHIR_DATETIME -- use x.isoformat()
-    FHIR_TIME = (
-        "%H:%M:%S"
-    )  # https://www.hl7.org/fhir/codesystem-item-type.html#item-type-time  # noqa: E501
+    FHIR_TIME = "%H:%M:%S"  # https://www.hl7.org/fhir/codesystem-item-type.html#item-type-time  # noqa: E501
     FILENAME = "%Y-%m-%dT%H%M%S"  # e.g. 2013-07-24T200459
     FILENAME_DATE_ONLY = "%Y-%m-%d"  # e.g. 20130724
     HL7_DATETIME = "%Y%m%d%H%M%S%z"  # e.g. 20130724200407+0100

--- a/server/camcops_server/cc_modules/celery.py
+++ b/server/camcops_server/cc_modules/celery.py
@@ -299,7 +299,7 @@ def backoff_delay_s(attempts: int) -> float:
     As per https://blog.balthazar-rouberol.com/celery-best-practices.
 
     """
-    return 2.0 ** attempts
+    return 2.0**attempts
 
 
 def jittered_delay_s() -> float:

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -557,9 +557,7 @@ OPENSSL_SRC_URL = (
 
 SQLCIPHER_GIT_URL = "https://github.com/sqlcipher/sqlcipher.git"
 # SQLCIPHER_GIT_COMMIT = "c6f709fca81c910ba133aaf6330c28e01ccfe5f8"  # SQLCipher version 3.4.2, 21 Dec 2017  # noqa
-SQLCIPHER_GIT_COMMIT = (
-    "750f5e32474ee23a423376203e671cab9841c67a"
-)  # SQLCipher version 4.2.0, 29 May 2019  # noqa
+SQLCIPHER_GIT_COMMIT = "750f5e32474ee23a423376203e671cab9841c67a"  # SQLCipher version 4.2.0, 29 May 2019  # noqa
 
 # - Note that there's another URL for the Android binary packages
 # - SQLCipher supports OpenSSL 1.1.0 as of SQLCipher 3.4.1
@@ -578,12 +576,8 @@ MIN_MACOS_VERSION = "10.10"  # ... with 10.7, SQLCipher's "configure" fails
 
 # GNU tools
 
-CONFIG_GUESS_MASTER = (
-    "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess"
-)  # noqa
-CONFIG_SUB_MASTER = (
-    "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"
-)  # noqa
+CONFIG_GUESS_MASTER = "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess"  # noqa
+CONFIG_SUB_MASTER = "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"  # noqa
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
following removal of maxtasksperchild in Celery 5.0
