### PR TITLE
EDEQ: Refactor subscale() to use self.mean_fields()

### DIFF
--- a/server/camcops_server/tasks/edeq.py
+++ b/server/camcops_server/tasks/edeq.py
@@ -331,12 +331,10 @@ class Edeq(TaskHasPatientMixin, Task, metaclass=EdeqMetaclass):
         return self.subscale(self.WEIGHT_CONCERN_FIELD_NAMES)
 
     def subscale(self, field_names: List[str]) -> Optional[float]:
-        # todo:: EDEQ: consider self.mean_fields() instead
-        scores = [getattr(self, q) for q in field_names]
-        if None in scores:
+        if self.any_fields_none(field_names):
             return None
 
-        return statistics.mean(scores)
+        return self.mean_fields(field_names)
 
     def global_score(self) -> Optional[float]:
         subscales = [


### PR DESCRIPTION
As suggested I've refactored the subscale calculation in the EDEQ task to use `self.mean_fields()`

I think it's probably better not to expand the options to mean_fields() any further. Instead I've just added a check in the task to see if any fields are None before calling it.