### PR TITLE
Changes to the demo Apache config

### DIFF
--- a/docs/source/administrator/_camcops_server_allhelp.txt
+++ b/docs/source/administrator/_camcops_server_allhelp.txt
@@ -104,13 +104,15 @@ optional arguments:
 ===============================================================================
 Help for command 'demo_apache_config'
 ===============================================================================
-usage: camcops_server demo_apache_config [-h] [-v]
+usage: camcops_server demo_apache_config [-h] [-v] [--path PATH]
 
 Print a demo Apache config file section for CamCOPS
 
 optional arguments:
   -h, --help     show this help message and exit
   -v, --verbose  Be verbose (default: False)
+  --path PATH    Path where CamCOPS should appear on the server e.g. 'camcops'
+                 for https://example.com/camcops (default: )
 
 ===============================================================================
 Help for command 'upgrade_db'

--- a/docs/source/administrator/_demo_apache_config.conf
+++ b/docs/source/administrator/_demo_apache_config.conf
@@ -26,15 +26,15 @@
 
         # CHANGE THIS: aim the alias at your own institutional logo.
 
-    Alias /camcops/static/logo_local.png /usr/share/camcops/venv/lib/python3.6/site-packages/camcops_server/static/logo_local.png
+    Alias /static/logo_local.png /usr/share/camcops/venv/lib/python3.8/site-packages/camcops_server/static/logo_local.png
 
         # We move from more specific to less specific aliases; the first match
         # takes precedence. (Apache will warn about conflicting aliases if
         # specified in a wrong, less-to-more-specific, order.)
 
-    Alias /camcops/static/ /usr/share/camcops/venv/lib/python3.6/site-packages/camcops_server/static/
+    Alias /static/ /usr/share/camcops/venv/lib/python3.8/site-packages/camcops_server/static/
 
-    <Directory /usr/share/camcops/venv/lib/python3.6/site-packages/camcops_server/static>
+    <Directory /usr/share/camcops/venv/lib/python3.8/site-packages/camcops_server/static>
         Require all granted
 
         # ... for old Apache versions (e.g. 2.2), use instead:
@@ -44,7 +44,7 @@
 
         # Don't ProxyPass the static files; we'll serve them via Apache.
 
-    ProxyPassMatch ^/camcops/static/ !
+    ProxyPassMatch ^/static/ !
 
         # ---------------------------------------------------------------------
         # 2. Proxy requests to the CamCOPS web server and back; allow access
@@ -55,27 +55,13 @@
         #
         # NOTES
         #
-        # - When you ProxyPass /camcops, you should browse to
+        # - When you ProxyPass /, you should browse to (e.g.)
         #
-        #       https://YOURSITE/camcops
+        #       https://camcops.example.com/
         #
         #   and point your tablet devices to
         #
-        #       https://YOURSITE/camcops/api
-        #
-        # - Don't specify trailing slashes for the ProxyPass and
-        #   ProxyPassReverse directives.
-        #   If you do, http://host/camcops will fail though
-        #              http://host/camcops/ will succeed.
-        #
-        #   - An alternative fix is to enable mod_rewrite (e.g. sudo a2enmod
-        #     rewrite), then add these commands:
-        #
-        #       RewriteEngine on
-        #       RewriteRule ^/camcops$ camcops/ [L,R=301]
-        #
-        #     which will redirect requests without the trailing slash to a
-        #     version with the trailing slash.
+        #       https://camcops.example.com/api
         #
         # - Ensure that you put the CORRECT PROTOCOL (http, https) in the rules
         #   below.
@@ -112,8 +98,8 @@
         # Note the use of "http" (reflecting the backend), not https (like the
         # front end).
 
-    # ProxyPass /camcops http://127.0.0.1:8000 retry=0 timeout=300
-    # ProxyPassReverse /camcops http://127.0.0.1:8000
+    # ProxyPass / http://127.0.0.1:8000 retry=0 timeout=300
+    # ProxyPassReverse / http://127.0.0.1:8000
 
         # #####################################################################
         # UNIX SOCKET METHOD (Apache 2.4.9 and higher)
@@ -176,8 +162,8 @@
         #
         # - https://emptyhammock.com/projects/info/pyweb/webconfig.html
 
-    ProxyPass /camcops unix:/run/camcops/camcops.socket|http://dummy1 retry=0 timeout=300
-    ProxyPassReverse /camcops unix:/run/camcops/camcops.socket|http://dummy1
+    ProxyPass / unix:/run/camcops/camcops.socket|http://dummy1 retry=0 timeout=300
+    ProxyPassReverse / unix:/run/camcops/camcops.socket|http://dummy1
 
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # (b) Allow proxy over SSL.
@@ -188,7 +174,7 @@
 
     SSLProxyEngine on
 
-    <Location /camcops>
+    <Location />
 
             # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             # (c) Allow access
@@ -210,7 +196,6 @@
             # Enable mod_headers (e.g. "sudo a2enmod headers") and set:
 
         RequestHeader set X-Forwarded-Proto https
-        RequestHeader set X-Script-Name /camcops
 
             # ... then ensure the TRUSTED_PROXY_HEADERS setting in the CamCOPS
             # config file includes:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3685,3 +3685,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fix RPM build to work with Python 3.8 and RHEL 8.
+
+- Command ``camcops_server demo_apache_config`` now defaults to the server
+  being hosted at (e.g.) ``https://camcops.example.com/`` instead of ``https://camcops.example.com/camcops``. There is now a ``--path`` argument to generate the demo Apache config file for a particular location. For the old behaviour: ``camcops_server demo_apache_config --path camcops``

--- a/server/camcops_server/camcops_server.py
+++ b/server/camcops_server/camcops_server.py
@@ -141,12 +141,12 @@ def print_demo_supervisor_config() -> None:
     print(get_demo_supervisor_config())
 
 
-def print_demo_apache_config() -> None:
+def print_demo_apache_config(rootpath: str) -> None:
     """
     Prints a demonstration Apache HTTPD config file segment (for CamCOPS)
     to stdout.
     """
-    print(get_demo_apache_config())
+    print(get_demo_apache_config(rootpath=rootpath))
 
 
 # =============================================================================
@@ -737,7 +737,15 @@ def camcops_main() -> int:
         help="Print a demo Apache config file section for CamCOPS",
     )
     demoapacheconf_parser.set_defaults(
-        func=lambda args: print_demo_apache_config()
+        func=lambda args: print_demo_apache_config(rootpath=args.path)
+    )
+    demoapacheconf_parser.add_argument(
+        "--path",
+        default="",
+        help=(
+            "Path where CamCOPS should appear on the server "
+            "e.g. 'camcops' for https://example.com/camcops"
+        ),
     )
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
- Make the demo Apache config default to the application being served at` / `instead of `/camcops`
- New `--path` argument to generate an Apache config for an alternative path (`--path camcops` for the old behaviour).
- Default to Python 3.8.
- Provide appropriate comments based on the path