### PR TITLE
Fix deb package install on Ubuntu 22.04. Minimum Python version now 3.8

### DIFF
--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -16,7 +16,7 @@ jobs:
     build-and-install-package:
         strategy:
             matrix:
-                python-version: [3.8, 3.9, "3.10", 3.11]
+                python-version: [3.8, 3.9, "3.10"]
                 # LTS versions
                 os: [ubuntu-20.04, ubuntu-22.04]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -9,6 +9,9 @@ on:
             - .github/workflows/build-and-install-packages.yml
             - .github/workflows/scripts/build_packages.sh
             - .github/workflows/scripts/change_apt_mirror.sh
+            - server/tools/MAKE_LINUX_PACKAGES.py
+            - server/requirements-deb.txt
+            - server/requirements-rpm.txt
 jobs:
     build-and-install-package:
         strategy:

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -15,6 +15,7 @@ on:
 jobs:
     build-and-install-package:
         strategy:
+            fail-fast: false
             matrix:
                 python-version: [3.8, 3.9, "3.10"]
                 # LTS versions

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -37,6 +37,9 @@ jobs:
                   set -eux -o pipefail
                   ${GITHUB_WORKSPACE}/.github/scripts/build_packages.sh
                   echo installing debian package
+                  # Possible scope for confusion here: at this point we should
+                  # be running whatever version of Python the package depends
+                  # on.
                   server/tools/REINSTALL_DEBIAN_PACKAGE.sh
                   echo checking packages for conflicts
                   /usr/share/camcops/venv/bin/pip check

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -15,7 +15,6 @@ on:
 jobs:
     build-and-install-package:
         strategy:
-            fail-fast: false
             matrix:
                 python-version: [3.8, 3.9, "3.10"]
                 # LTS versions

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -16,7 +16,7 @@ jobs:
     build-and-install-package:
         strategy:
             matrix:
-                python-version: [3.8, 3.9, 3.10, 3.11]
+                python-version: [3.8, 3.9, "3.10", 3.11]
                 # LTS versions
                 os: [ubuntu-20.04, ubuntu-22.04]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -16,10 +16,7 @@ jobs:
     build-and-install-package:
         strategy:
             matrix:
-                # NumPy 1.21 incompatible with python 3.10
-                # For the time being we're on 1.21.5 (see setup.py)
-                # NumPy >= 1.22 incompatible with python 3.7
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.8, 3.9, 3.10, 3.11]
                 # LTS versions
                 os: [ubuntu-20.04, ubuntu-22.04]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-install-packages.yml
+++ b/.github/workflows/build-and-install-packages.yml
@@ -1,0 +1,39 @@
+---
+# yamllint disable rule:line-length
+name: Build and install Linux packages
+# yamllint disable-line rule:truthy
+on:
+    push:
+        paths:
+            - '**.py'
+            - .github/workflows/build-and-install-packages.yml
+            - .github/workflows/scripts/build_packages.sh
+            - .github/workflows/scripts/change_apt_mirror.sh
+jobs:
+    build-and-install-package:
+        strategy:
+            matrix:
+                # NumPy 1.21 incompatible with python 3.10
+                # For the time being we're on 1.21.5 (see setup.py)
+                # NumPy >= 1.22 incompatible with python 3.7
+                python-version: [3.7, 3.8, 3.9]
+                # LTS versions
+                os: [ubuntu-20.04, ubuntu-22.04]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Change apt mirror
+              run: |
+                  set -eux -o pipefail
+                  ${GITHUB_WORKSPACE}/.github/scripts/change_apt_mirror.sh
+            - name: Build and install debian package
+              run: |
+                  set -eux -o pipefail
+                  ${GITHUB_WORKSPACE}/.github/scripts/build_packages.sh
+                  echo installing debian package
+                  server/tools/REINSTALL_DEBIAN_PACKAGE.sh
+                  echo checking packages for conflicts
+                  /usr/share/camcops/venv/bin/pip check

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -9,7 +9,7 @@ on:
             - .github/workflows/build-qt.yml
 jobs:
     build-qt:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,9 @@ jobs:
                 include:
                     - name: ubuntu-20.04
                       os: ubuntu-20.04
+                      # TODO: Newer versions will change the formatting of help text
+                      # possibly for the better
                       python-version: 3.8
-                    - name: ubuntu-22.04
-                      os: ubuntu-22.04
-                      python-version: "3.10"
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,14 @@ on: push
 
 jobs:
     build-docs:
-        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                include:
+                    - name: ubuntu-20.04
+                      os: ubuntu-20.04
+                    - name: ubuntu-22.04
+                      os: ubuntu-22.04
+        runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3
             - name: Change apt mirror

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,18 @@ jobs:
                 include:
                     - name: ubuntu-20.04
                       os: ubuntu-20.04
+                      python-version: 3.8
                     - name: ubuntu-22.04
                       os: ubuntu-22.04
+                      # Problems with older numpy and 3.10
+                      # https://github.com/numpy/numpy/issues/19033
+                      python-version: 3.9
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
             - name: Change apt mirror
               run: |
                   set -eux -o pipefail

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,11 @@ jobs:
                       python-version: 3.8
                     - name: ubuntu-22.04
                       os: ubuntu-22.04
-                      # Problems with older numpy and 3.10
+                      # Problem with older numpy and 3.10
                       # https://github.com/numpy/numpy/issues/19033
-                      python-version: 3.9
+                      # Also python 3.9 seems to change (fix?) the output
+                      # of help text for various CLI tools
+                      python-version: 3.8
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
                       python-version: 3.8
                     - name: ubuntu-22.04
                       os: ubuntu-22.04
-                      python-version: 3.10
+                      python-version: "3.10"
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,11 +14,7 @@ jobs:
                       python-version: 3.8
                     - name: ubuntu-22.04
                       os: ubuntu-22.04
-                      # Problem with older numpy and 3.10
-                      # https://github.com/numpy/numpy/issues/19033
-                      # Also python 3.9 seems to change (fix?) the output
-                      # of help text for various CLI tools
-                      python-version: 3.8
+                      python-version: 3.10
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -70,7 +70,8 @@ jobs:
                   # 44715 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/19038
                   # 44716 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/19000
                   # 44717 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/18993
-                  safety check --full-report --ignore=44715 --ignore=44716 --ignore=44717
+                  # 51457 py no fix yet https://github.com/pytest-dev/py/issues/287
+                  safety check --full-report --ignore=44715 --ignore=44716 --ignore=44717 --ignore=51457
                   echo running pre-commit checks
                   pre-commit run --all-files
                   export CAMCOPS_CONFIG_FILE="${HOME}/camcops.cfg"

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
     pip-install-and-tests:
         strategy:
+            fail-fast: false
             matrix:
                 python-version: [3.8, 3.9, "3.10"]
                 # LTS versions

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -11,7 +11,6 @@ on:
 jobs:
     pip-install-and-tests:
         strategy:
-            fail-fast: false
             matrix:
                 python-version: [3.8, 3.9, "3.10"]
                 # LTS versions

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -12,7 +12,7 @@ jobs:
     pip-install-and-tests:
         strategy:
             matrix:
-                python-version: [3.8, 3.9, 3.10, 3.11]
+                python-version: [3.8, 3.9, "3.10", 3.11]
                 # LTS versions
                 os: [ubuntu-20.04, ubuntu-22.04]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -1,19 +1,24 @@
 ---
 # yamllint disable rule:line-length
-name: Build
+name: Pip install and tests
 # yamllint disable-line rule:truthy
 on:
     push:
         paths:
             - '**.py'
-            - .github/workflows/push-to-repository.yml
-            - .github/workflows/scripts/build_packages.sh
+            - .github/workflows/pip-install-and-tests.yml
+            - .github/workflows/scripts/change_apt_mirror.sh
 jobs:
     pip-install-and-tests:
-        runs-on: ubuntu-latest
         strategy:
             matrix:
+                # NumPy 1.21 incompatible with python 3.10
+                # For the time being we're on 1.21.5 (see setup.py)
+                # NumPy >= 1.22 incompatible with python 3.7
                 python-version: [3.7, 3.8, 3.9]
+                # LTS versions
+                os: [ubuntu-20.04, ubuntu-22.04]
+        runs-on: ${{ matrix.os }}
         env:
             DB_DATABASE: camcops
             DB_CAMCOPS_USER: camcops
@@ -35,9 +40,8 @@ jobs:
                   mysql -e 'GRANT ALL PRIVILEGES ON `${{ env.DB_DATABASE }}`.* TO `${{ env.DB_CAMCOPS_USER }}`@`localhost`;' -u${{ env.DB_ROOT_USER  }} -p${{ env.DB_ROOT_PASSWORD }}
             - name: Change apt mirror
               run: |
-                  # azure.archive.ubuntu.com is flaky
-                  sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
-                  sudo apt-get update
+                  set -eux -o pipefail
+                  ${GITHUB_WORKSPACE}/.github/scripts/change_apt_mirror.sh
             - name: Pip install and tests
               run: |
                   set -xe
@@ -83,26 +87,3 @@ jobs:
                   camcops_server dev_downgrade_db --config ${CAMCOPS_CONFIG_FILE} --destination_db_revision 0001 --confirm_downgrade_db
                   camcops_server upgrade_db --config ${CAMCOPS_CONFIG_FILE} --show_sql_only
                   camcops_server upgrade_db --config ${CAMCOPS_CONFIG_FILE}
-
-    build-and-install-package:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                python-version: [3.7, 3.8, 3.9]
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - name: Change apt mirror
-              run: |
-                  set -eux -o pipefail
-                  ${GITHUB_WORKSPACE}/.github/scripts/change_apt_mirror.sh
-            - name: Build and install debian package
-              run: |
-                  set -eux -o pipefail
-                  ${GITHUB_WORKSPACE}/.github/scripts/build_packages.sh
-                  echo installing debian package
-                  server/tools/REINSTALL_DEBIAN_PACKAGE.sh
-                  echo checking packages for conflicts
-                  /usr/share/camcops/venv/bin/pip check

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -12,10 +12,7 @@ jobs:
     pip-install-and-tests:
         strategy:
             matrix:
-                # NumPy 1.21 incompatible with python 3.10
-                # For the time being we're on 1.21.5 (see setup.py)
-                # NumPy >= 1.22 incompatible with python 3.7
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.8, 3.9, 3.10, 3.11]
                 # LTS versions
                 os: [ubuntu-20.04, ubuntu-22.04]
         runs-on: ${{ matrix.os }}
@@ -67,11 +64,8 @@ jobs:
                   python -m pip install safety
                   echo checking packages for vulnerabilities
                   # All of these vulnerabilities look either harmless or very low risk
-                  # 44715 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/19038
-                  # 44716 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/19000
-                  # 44717 numpy fixed in 1.22 https://github.com/numpy/numpy/issues/18993
                   # 51457 py no fix yet https://github.com/pytest-dev/py/issues/287
-                  safety check --full-report --ignore=44715 --ignore=44716 --ignore=44717 --ignore=51457
+                  safety check --full-report --ignore=51457
                   echo running pre-commit checks
                   pre-commit run --all-files
                   export CAMCOPS_CONFIG_FILE="${HOME}/camcops.cfg"

--- a/.github/workflows/pip-install-and-tests.yml
+++ b/.github/workflows/pip-install-and-tests.yml
@@ -12,7 +12,7 @@ jobs:
     pip-install-and-tests:
         strategy:
             matrix:
-                python-version: [3.8, 3.9, "3.10", 3.11]
+                python-version: [3.8, 3.9, "3.10"]
                 # LTS versions
                 os: [ubuntu-20.04, ubuntu-22.04]
         runs-on: ${{ matrix.os }}

--- a/docs/recreate_inclusion_files.py
+++ b/docs/recreate_inclusion_files.py
@@ -157,6 +157,13 @@ def run_cmd(
 
 
 def main():
+    if sys.version_info >= (3, 9):
+        # TODO: Newer versions will change the formatting of help text
+        # possibly for the better. Needs investigating.
+        raise AssertionError(
+            "This script currently needs to be run with Python < 3.9."
+        )
+
     prohibit_env_vars(ENVVARS_PROHIBITED_DURING_DOC_BUILD)
 
     parser = argparse.ArgumentParser()

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3700,4 +3700,7 @@ Current C++/SQLite client, Python/SQLAlchemy server
 **Client and server v2.4.15, IN PROGRESS**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fix Debian package install on Ubuntu 22.04.
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/239
+
 - **Minimum Python version now Python 3.8.**

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3699,3 +3699,5 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 **Client and server v2.4.15, IN PROGRESS**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Minimum Python version now Python 3.8.**

--- a/server/camcops_server/cc_modules/cc_pythonversion.py
+++ b/server/camcops_server/cc_modules/cc_pythonversion.py
@@ -35,11 +35,13 @@ Python v3.7 was required as of CamCOPS v2.4.12, 2021. That enables:
 
 - dataclasses (v3.7)
 
-Not yet available:
+Python 3.8 was required as of CamCOPS v2.4.15, 2022. That enables:
 
 - assignment expressions, the "walrus" operator, ``:=`` (v3.8)
 - positional-only parameters, ``/`` (v3.8)
 - f-string ``=`` syntax to debug a variable (v3.8)
+
+Not yet available:
 
 - new dictionary merge/update syntax (v3.9)
 - string prefix/suffix removal functions (v3.9)
@@ -70,7 +72,7 @@ and separately (not necessarily within a CamCOPS virtual environment) in
 
 import sys
 
-MINIMUM_PYTHON_VERSION = (3, 7)
+MINIMUM_PYTHON_VERSION = (3, 8)
 
 
 def assert_minimum_python_version():

--- a/server/requirements-deb.txt
+++ b/server/requirements-deb.txt
@@ -25,10 +25,10 @@ libssl-dev  # SSL libraries
 # Python
 # =============================================================================
 
-python3
-python3-dev  # for <Python.h>, etc.
-python3-tk  # tkinter, for command-line UI code
-python3-venv  # or venv complains that ensurepip is not available
+python3.8
+python3.8-dev  # for <Python.h>, etc.
+python3.8-tk  # tkinter, for command-line UI code
+python3.8-venv  # or venv complains that ensurepip is not available
 
 # =============================================================================
 # Requirements for Python packages

--- a/server/requirements-deb.txt
+++ b/server/requirements-deb.txt
@@ -25,7 +25,7 @@ libssl-dev  # SSL libraries
 # Python
 # =============================================================================
 
-python  # or Lintian complains about the presence of Python scripts
+python3
 python3-dev  # for <Python.h>, etc.
 python3-tk  # tkinter, for command-line UI code
 python3-venv  # or venv complains that ensurepip is not available

--- a/server/requirements-deb.txt
+++ b/server/requirements-deb.txt
@@ -25,10 +25,10 @@ libssl-dev  # SSL libraries
 # Python
 # =============================================================================
 
-python3.8
-python3.8-dev  # for <Python.h>, etc.
-python3.8-tk  # tkinter, for command-line UI code
-python3.8-venv  # or venv complains that ensurepip is not available
+python3
+python3-dev  # for <Python.h>, etc.
+python3-tk  # tkinter, for command-line UI code
+python3-venv  # or venv complains that ensurepip is not available
 
 # =============================================================================
 # Requirements for Python packages

--- a/server/setup.py
+++ b/server/setup.py
@@ -95,7 +95,7 @@ INSTALL_REQUIRES = [
     "lockfile==0.12.2",  # File locking for background tasks
     "lxml==4.9.1",  # Will speed up openpyxl export [NO LONGER CRITICAL]
     "matplotlib==3.2.2",  # Used for trackers and some tasks. SLOW INSTALLATION.  # noqa
-    "numpy==1.21.5",  # Used by some tasks. SLOW INSTALLATION.
+    "numpy==1.23.5",  # Used by some tasks. SLOW INSTALLATION.
     "paginate==0.5.6",  # pagination for web server
     "pendulum==2.1.2",  # date/time classes
     "pexpect==4.8.0",  # for open_sqlcipher.py
@@ -194,9 +194,10 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Medical Science Apps.",
     ],
     keywords="cardinal",

--- a/server/setup.py
+++ b/server/setup.py
@@ -197,7 +197,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Medical Science Apps.",
     ],
     keywords="cardinal",

--- a/server/setup.py
+++ b/server/setup.py
@@ -117,7 +117,7 @@ INSTALL_REQUIRES = [
     "scipy==1.9.3",  # used by some tasks. slow installation.
     "semantic_version==2.8.5",  # semantic versioning; better than semver
     "sqlalchemy==1.3.24",  # database access
-    "statsmodels==0.11.1",  # e.g. logistic regression
+    "statsmodels==0.13.5",  # e.g. logistic regression
     "twilio==7.9.3",  # SMS backend for Multi-factor authentication
     "urllib3==1.26.7",  # dependency, pinned to avoid vulnerabilities
     "Wand==0.6.1",  # ImageMagick binding

--- a/server/setup.py
+++ b/server/setup.py
@@ -101,7 +101,7 @@ INSTALL_REQUIRES = [
     "pexpect==4.8.0",  # for open_sqlcipher.py
     "pdfkit==1.0.0",  # wkhtmltopdf interface, for PDF generation from HTML
     "phonenumbers==8.12.30",  # phone number parsing, storing and validating
-    "py==1.10.0",  # dependency, pinned to avoid CVE-2020-29651
+    "py==1.11.0",  # dependency, pinned to avoid CVE-2022-42969
     "pycap==1.1.1",  # REDCap integration
     "Pillow==9.0.1",  # used by a dependency; pin for security warnings
     "Pygments==2.13.0",  # Syntax highlighting for introspection/DDL

--- a/server/setup.py
+++ b/server/setup.py
@@ -110,7 +110,7 @@ INSTALL_REQUIRES = [
     "pyotp==2.6.0",  # Multi-factor authentication
     "pyramid==1.10.8",  # web framework
     "pyramid_debugtoolbar==4.6.1",  # debugging for Pyramid
-    "pytest==6.0.2",  # automatic testing
+    "pytest==7.2.0",  # automatic testing
     "qrcode[pil]==7.2",  # for registering with Authenticators
     "requests==2.26",  # in fetch_snomed_codes.py and cc_sms.py, but also required by something else?  # noqa
     "sadisplay==0.4.9",  # SQL Alchemy schema display script

--- a/server/setup.py
+++ b/server/setup.py
@@ -114,7 +114,7 @@ INSTALL_REQUIRES = [
     "qrcode[pil]==7.2",  # for registering with Authenticators
     "requests==2.26",  # in fetch_snomed_codes.py and cc_sms.py, but also required by something else?  # noqa
     "sadisplay==0.4.9",  # SQL Alchemy schema display script
-    "scipy==1.5.4",  # used by some tasks. slow installation.
+    "scipy==1.9.3",  # used by some tasks. slow installation.
     "semantic_version==2.8.5",  # semantic versioning; better than semver
     "sqlalchemy==1.3.24",  # database access
     "statsmodels==0.11.1",  # e.g. logistic regression

--- a/server/setup.py
+++ b/server/setup.py
@@ -101,7 +101,7 @@ INSTALL_REQUIRES = [
     "pexpect==4.8.0",  # for open_sqlcipher.py
     "pdfkit==1.0.0",  # wkhtmltopdf interface, for PDF generation from HTML
     "phonenumbers==8.12.30",  # phone number parsing, storing and validating
-    "py==1.11.0",  # dependency, pinned to avoid CVE-2022-42969
+    "py==1.11.0",  # dependency, pinned to avoid CVE-2020-29651
     "pycap==1.1.1",  # REDCap integration
     "Pillow==9.0.1",  # used by a dependency; pin for security warnings
     "Pygments==2.13.0",  # Syntax highlighting for introspection/DDL

--- a/server/tools/MAKE_LINUX_PACKAGES.py
+++ b/server/tools/MAKE_LINUX_PACKAGES.py
@@ -247,7 +247,6 @@ system_python_executable()
     # Use as: $(system_python_executable) ...
 
     python_options=(
-        python3.11 python311
         python3.10 python310
         python3.9 python39
         python3.8 python38
@@ -551,7 +550,7 @@ Priority: optional
 Architecture: all
 Maintainer: Rudolf Cardinal <rnc1001@cam.ac.uk>
 Depends: {DEPENDENCIES}
-X-Python3-Version: >= 3.8, <= 3.11
+X-Python3-Version: >= 3.8, <= 3.10
 Recommends: mysql-workbench
 Description: Cambridge Cognitive and Psychiatric Test Kit (CamCOPS), server
  packages.

--- a/server/tools/MAKE_LINUX_PACKAGES.py
+++ b/server/tools/MAKE_LINUX_PACKAGES.py
@@ -1046,7 +1046,16 @@ def build_package() -> None:
     # fail-in-warnings has gone in 2.62.0
     # It isn't clear if lintian now exits with 0 on warnings (the previous
     # default). Future versions seems to have a more flexible --fail-on option
-    call(["lintian", PACKAGENAME])
+    call(
+        [
+            "lintian",
+            PACKAGENAME,
+            "--suppress-tags",
+            # This check has gone from later versions of lintian, presumably
+            # because there is no longer a python package
+            "python-script-but-no-python-dep",
+        ]
+    )
 
     log.info("Converting to RPM")
     call(

--- a/server/tools/MAKE_LINUX_PACKAGES.py
+++ b/server/tools/MAKE_LINUX_PACKAGES.py
@@ -1073,6 +1073,10 @@ def build_package() -> None:
     if tags_to_suppress:
         lintian_args += ["--suppress-tags", ",".join(tags_to_suppress)]
 
+    # Will wrongly generate a warning because of the comment in the prerm
+    # script
+    # tag: uses-dpkg-database-directly
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995253
     call(lintian_args)
 
     log.info("Converting to RPM")

--- a/server/tools/MAKE_LINUX_PACKAGES.py
+++ b/server/tools/MAKE_LINUX_PACKAGES.py
@@ -247,9 +247,10 @@ system_python_executable()
     # Use as: $(system_python_executable) ...
 
     python_options=(
+        python3.11 python311
+        python3.10 python310
         python3.9 python39
         python3.8 python38
-        python3.7 python37
         python3
         python
     )
@@ -550,7 +551,7 @@ Priority: optional
 Architecture: all
 Maintainer: Rudolf Cardinal <rnc1001@cam.ac.uk>
 Depends: {DEPENDENCIES}
-X-Python3-Version: >= 3.7, <= 3.9
+X-Python3-Version: >= 3.8, <= 3.11
 Recommends: mysql-workbench
 Description: Cambridge Cognitive and Psychiatric Test Kit (CamCOPS), server
  packages.

--- a/server/tools/install_virtualenv.py
+++ b/server/tools/install_virtualenv.py
@@ -49,7 +49,7 @@ try:
 except ImportError:
     distro = None
 
-assert sys.version_info >= (3, 7), "Need Python 3.7 or higher"
+assert sys.version_info >= (3, 8), "Need Python 3.8 or higher"
 LINUX = platform.system() == "Linux"
 if distro:
     LINUX_DIST = distro.linux_distribution()[0].lower()


### PR DESCRIPTION
Some of the GitHub Actions were failing because `ubuntu-latest` now means 22.04 LTS instead of 20.04 LTS.

I've changed some of the actions to test with both Ubuntu versions and for others, where this was not important just picked one that works. The DEB package should now install on Ubuntu 22.04 (closes #239) .

I've split the `push-to-repository.yml` action into two.

Because Ubuntu 22.04 uses Python 3.10 by default (older versions are in the deadsnakes PPA), I've made the minimum supported Python version 3.8. It's going EOL in June anyway and it means we can use later versions of numpy. 

Note that we still need to generate the docs with Python 3.8 because something in Python >= 3.9 has changed (possibly for the better) the formatting of the auto-generated help text for various command line tools. One to investigate.
