### PR TITLE
BMI: Make waist circumference optional again

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3742,3 +3742,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
 - :func:`camcops_server.cc_modules.cc_task.Task.get_extrastring_taskname`
   changed to a classmethod. Likewise ``extrastrings_exist``, ``wxstring``,
   ``xstring``, ``make_options_from_xstrings``.
+
+- Bug fix: Make BMI waist circumference optional again.
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/264

--- a/tablet_qt/questionnairelib/quheight.cpp
+++ b/tablet_qt/questionnairelib/quheight.cpp
@@ -34,8 +34,9 @@
 #include "questionnairelib/qumcq.h"
 
 
-QuHeight::QuHeight(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector)
-    : QuMeasurement(fieldref, unit_selector),
+QuHeight::QuHeight(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+                   bool mandatory)
+    : QuMeasurement(fieldref, unit_selector, mandatory),
     m_fr_m(nullptr),
     m_fr_ft(nullptr),
     m_fr_in(nullptr)
@@ -86,9 +87,9 @@ void QuHeight::setUpFields()
     FieldRef::SetterFunction set_m = std::bind(&QuHeight::setM, this, std::placeholders::_1);
     FieldRef::SetterFunction set_ft = std::bind(&QuHeight::setFt, this, std::placeholders::_1);
     FieldRef::SetterFunction set_in = std::bind(&QuHeight::setIn, this, std::placeholders::_1);
-    m_fr_m = FieldRefPtr(new FieldRef(get_m, set_m, true));
-    m_fr_ft = FieldRefPtr(new FieldRef(get_ft, set_ft, true));
-    m_fr_in = FieldRefPtr(new FieldRef(get_in, set_in, true));
+    m_fr_m = FieldRefPtr(new FieldRef(get_m, set_m, m_mandatory));
+    m_fr_ft = FieldRefPtr(new FieldRef(get_ft, set_ft, m_mandatory));
+    m_fr_in = FieldRefPtr(new FieldRef(get_in, set_in, m_mandatory));
 }
 
 

--- a/tablet_qt/questionnairelib/quheight.h
+++ b/tablet_qt/questionnairelib/quheight.h
@@ -30,7 +30,8 @@ class QuHeight : public QuMeasurement
     // Height in metres question type with imperial conversion
     Q_OBJECT
 public:
-    QuHeight(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector);
+    QuHeight(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+             bool mandatory = true);
     void setUpFields();
 
 protected:

--- a/tablet_qt/questionnairelib/qumass.cpp
+++ b/tablet_qt/questionnairelib/qumass.cpp
@@ -34,8 +34,9 @@
 #include "questionnairelib/qumcq.h"
 
 
-QuMass::QuMass(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector)
-    : QuMeasurement(fieldref, unit_selector),
+QuMass::QuMass(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+               bool mandatory)
+    : QuMeasurement(fieldref, unit_selector, mandatory),
     m_fr_kg(nullptr),
     m_fr_st(nullptr),
     m_fr_lb(nullptr),
@@ -89,10 +90,10 @@ void QuMass::setUpFields()
     FieldRef::SetterFunction set_st = std::bind(&QuMass::setSt, this, std::placeholders::_1);
     FieldRef::SetterFunction set_lb = std::bind(&QuMass::setLb, this, std::placeholders::_1);
     FieldRef::SetterFunction set_oz = std::bind(&QuMass::setOz, this, std::placeholders::_1);
-    m_fr_kg = FieldRefPtr(new FieldRef(get_kg, set_kg, true));
-    m_fr_st = FieldRefPtr(new FieldRef(get_st, set_st, true));
-    m_fr_lb = FieldRefPtr(new FieldRef(get_lb, set_lb, true));
-    m_fr_oz = FieldRefPtr(new FieldRef(get_oz, set_oz, true));
+    m_fr_kg = FieldRefPtr(new FieldRef(get_kg, set_kg, m_mandatory));
+    m_fr_st = FieldRefPtr(new FieldRef(get_st, set_st, m_mandatory));
+    m_fr_lb = FieldRefPtr(new FieldRef(get_lb, set_lb, m_mandatory));
+    m_fr_oz = FieldRefPtr(new FieldRef(get_oz, set_oz, m_mandatory));
 }
 
 

--- a/tablet_qt/questionnairelib/qumass.h
+++ b/tablet_qt/questionnairelib/qumass.h
@@ -30,7 +30,8 @@ class QuMass : public QuMeasurement
     // Mass in kilograms question type with imperial conversion
     Q_OBJECT
 public:
-    QuMass(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector);
+    QuMass(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+           bool mandatory = true);
     void setUpFields();
 
 

--- a/tablet_qt/questionnairelib/qumeasurement.cpp
+++ b/tablet_qt/questionnairelib/qumeasurement.cpp
@@ -29,7 +29,9 @@
 #include "questionnairelib/quunitselector.h"
 
 
-QuMeasurement::QuMeasurement(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector) :
+QuMeasurement::QuMeasurement(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+                             bool mandatory) :
+    m_mandatory(mandatory),
     m_fieldref(fieldref),
     m_unit_selector(unit_selector),
     m_metric_grid(nullptr),

--- a/tablet_qt/questionnairelib/qumeasurement.h
+++ b/tablet_qt/questionnairelib/qumeasurement.h
@@ -29,8 +29,8 @@ class QuMeasurement : public QuElement
 
     Q_OBJECT
 public:
-    QuMeasurement(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector);
-
+    QuMeasurement(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+                  bool mandatory = true);
 public slots:
     void unitsChanged(int units);
 protected:
@@ -45,6 +45,7 @@ protected:
     virtual void setUpFields() = 0;
     QVariant getFieldrefValue() const;
     bool setFieldrefValue(const QVariant& value);
+    bool m_mandatory;
 
 private:
     FieldRefPtr m_fieldref;

--- a/tablet_qt/questionnairelib/quwaist.cpp
+++ b/tablet_qt/questionnairelib/quwaist.cpp
@@ -34,8 +34,9 @@
 #include "questionnairelib/qumcq.h"
 
 
-QuWaist::QuWaist(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector)
-    : QuMeasurement(fieldref, unit_selector),
+QuWaist::QuWaist(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+                 bool mandatory)
+    : QuMeasurement(fieldref, unit_selector, mandatory),
     m_fr_cm(nullptr),
     m_fr_in(nullptr)
 {
@@ -81,8 +82,8 @@ void QuWaist::setUpFields()
     FieldRef::GetterFunction get_in = std::bind(&QuWaist::getIn, this);
     FieldRef::SetterFunction set_cm = std::bind(&QuWaist::setCm, this, std::placeholders::_1);
     FieldRef::SetterFunction set_in = std::bind(&QuWaist::setIn, this, std::placeholders::_1);
-    m_fr_cm = FieldRefPtr(new FieldRef(get_cm, set_cm, true));
-    m_fr_in = FieldRefPtr(new FieldRef(get_in, set_in, true));
+    m_fr_cm = FieldRefPtr(new FieldRef(get_cm, set_cm, m_mandatory));
+    m_fr_in = FieldRefPtr(new FieldRef(get_in, set_in, m_mandatory));
 }
 
 

--- a/tablet_qt/questionnairelib/quwaist.h
+++ b/tablet_qt/questionnairelib/quwaist.h
@@ -30,7 +30,8 @@ class QuWaist : public QuMeasurement
     // Waist circumference in centimetres queestion type with imperial conversion
     Q_OBJECT
 public:
-    QuWaist(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector);
+    QuWaist(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,
+            bool mandatory = true);
     void setUpFields();
 
 protected:

--- a/tablet_qt/questionnairelib/quwaist.h
+++ b/tablet_qt/questionnairelib/quwaist.h
@@ -27,7 +27,7 @@
 
 class QuWaist : public QuMeasurement
 {
-    // Waist circumference in centimetres queestion type with imperial conversion
+    // Waist circumference in centimetres question type with imperial conversion
     Q_OBJECT
 public:
     QuWaist(FieldRefPtr fieldref, QPointer<QuUnitSelector> unit_selector,

--- a/tablet_qt/tasks/bmi.cpp
+++ b/tablet_qt/tasks/bmi.cpp
@@ -141,7 +141,8 @@ OpenableWidget* Bmi::editor(const bool read_only)
     auto mass_units = new QuUnitSelector(CommonOptions::massUnits());
     auto mass_edit = new QuMass(fieldRef(FN_MASS_KG), mass_units);
     auto waist_units = new QuUnitSelector(CommonOptions::waistUnits());
-    auto waist_edit = new QuWaist(fieldRef(FN_WAIST_CM), waist_units);
+    auto waist_edit = new QuWaist(fieldRef(FN_WAIST_CM), waist_units,
+                                  false); // Not mandatory
 
     // Comments
     FieldRefPtr fr_comment = fieldRef(FN_COMMENT, false);


### PR DESCRIPTION
Fixes #264 . QuMass, QuHeight and QuWaist can now all be specified as optional. For BMI we set the waist circumference field to be optional.