### PR TITLE
Use SecureTransport instead of OpenSSL when building Qt on iOS

### DIFF
--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -350,7 +350,7 @@ ios {
     STATIC_LIB_EXT = ".a"
     DYNAMIC_LIB_EXT = ".dylib"
     CAMCOPS_QT_LINKAGE = "static"
-    CAMCOPS_OPENSSL_LINKAGE = "none"
+    CAMCOPS_OPENSSL_LINKAGE = "static"
 
     # Both iphoneos and iphonesimulator are set ?!
     CONFIG(iphoneos, iphoneos|iphonesimulator) {
@@ -409,8 +409,6 @@ equals(CAMCOPS_OPENSSL_LINKAGE, "static") {
     message("Using static linkage from CamCOPS to OpenSSL")
 } else:equals(CAMCOPS_OPENSSL_LINKAGE, "dynamic") {
     message("Using dynamic linkage from CamCOPS to OpenSSL")
-} else:equals(CAMCOPS_OPENSSL_LINKAGE, "none") {
-    message("Using native SSL library")
 } else {
     error("Linkage method from CamCOPS to OpenSSL not specified")
 }
@@ -508,7 +506,7 @@ equals(CAMCOPS_OPENSSL_LINKAGE, "static") {
     LIBS += "-L$${OPENSSL_DIR}"  # path; shouldn't be necessary for static linkage! Residual problem.
     LIBS += "$${OPENSSL_DIR}/libcrypto$${STATIC_LIB_EXT}"  # raw filename, not -l
     LIBS += "$${OPENSSL_DIR}/libssl$${STATIC_LIB_EXT}"  # raw filename, not -l
-} else:equals(CAMCOPS_QT_LINKAGE, "dynamic") {
+} else {
     LIBS += "-L$${OPENSSL_DIR}"  # path
     LIBS += "-lcrypto"
     LIBS += "-lssl"

--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -350,7 +350,7 @@ ios {
     STATIC_LIB_EXT = ".a"
     DYNAMIC_LIB_EXT = ".dylib"
     CAMCOPS_QT_LINKAGE = "static"
-    CAMCOPS_OPENSSL_LINKAGE = "static"
+    CAMCOPS_OPENSSL_LINKAGE = "none"
 
     # Both iphoneos and iphonesimulator are set ?!
     CONFIG(iphoneos, iphoneos|iphonesimulator) {
@@ -409,6 +409,8 @@ equals(CAMCOPS_OPENSSL_LINKAGE, "static") {
     message("Using static linkage from CamCOPS to OpenSSL")
 } else:equals(CAMCOPS_OPENSSL_LINKAGE, "dynamic") {
     message("Using dynamic linkage from CamCOPS to OpenSSL")
+} else:equals(CAMCOPS_OPENSSL_LINKAGE, "none") {
+    message("Using native SSL library")
 } else {
     error("Linkage method from CamCOPS to OpenSSL not specified")
 }
@@ -506,7 +508,7 @@ equals(CAMCOPS_OPENSSL_LINKAGE, "static") {
     LIBS += "-L$${OPENSSL_DIR}"  # path; shouldn't be necessary for static linkage! Residual problem.
     LIBS += "$${OPENSSL_DIR}/libcrypto$${STATIC_LIB_EXT}"  # raw filename, not -l
     LIBS += "$${OPENSSL_DIR}/libssl$${STATIC_LIB_EXT}"  # raw filename, not -l
-} else {
+} else:equals(CAMCOPS_QT_LINKAGE, "dynamic") {
     LIBS += "-L$${OPENSSL_DIR}"  # path
     LIBS += "-lcrypto"
     LIBS += "-lssl"

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -3348,7 +3348,7 @@ def build_qt(cfg: Config, target_platform: Platform) -> str:
         # Copying openssl/Configurations/10-main.conf
         crypto_dependencies = "-lws2_32 -lgdi32 -ladvapi32 -lcrypt32 -luser32"
 
-    if cfg.use_openssl_with_qt:
+    if target_platform.use_openssl_with_qt:
         opensslrootdir, opensslworkdir = cfg.get_openssl_rootdir_workdir(
             target_platform
         )

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -3390,7 +3390,7 @@ def build_qt(cfg: Config, target_platform: Platform) -> str:
     objdirs = []  # type: List[str]
     libdirs = []
 
-    if cfg.use_openssl_with_qt:
+    if target_platform.use_openssl_with_qt:
         includedirs.append(openssl_include_root)  # #include files for OpenSSL
         libdirs.append(openssl_lib_root)  # libraries for OpenSSL
 
@@ -3404,7 +3404,7 @@ def build_qt(cfg: Config, target_platform: Platform) -> str:
         # "-gcc-sysroot": not required
     ]
 
-    if cfg.use_openssl_with_qt:
+    if target_platform.use_openssl_with_qt:
         qt_config_args.append("OPENSSL_LIBS=" + openssl_libs)
     else:
         qt_config_args.append("-no-openssl")
@@ -3555,7 +3555,7 @@ def build_qt(cfg: Config, target_platform: Platform) -> str:
         # ... http://stackoverflow.com/questions/1999654
         # ... https://forum.qt.io/topic/75056/configuring-qt-what-replaces-debug-and-release/7  # noqa: E501
 
-    if cfg.use_openssl_with_qt:
+    if target_platform.use_openssl_with_qt:
         # OpenSSL linkage?
         # For testing a new OpenSSL build, have cfg.qt_openssl_static=False, or
         # you have to rebuild Qt every time... extremely slow.


### PR DESCRIPTION
Closes #136, #278 

It's still a mystery why this is not working with OpenSSL.

https://developer.apple.com/documentation/security/secure_transport says "This API is considered legacy. Use the [Network](https://developer.apple.com/documentation/network) framework instead."

https://wiki.qt.io/Plans_for_Modules says "Investigate Apple's networking framework; SecureTransport was deprecated by Apple, need an alternative ". Qt are still shipping binaries with SecureTransport for iOS so I guess we wait to see what that alternative will be.

We still need to link OpenSSL when building CamCOPS so that SQLCipher will work.