### PR TITLE
Fix display of visual analogue scale on EQ-5D-5L task

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3783,3 +3783,10 @@ Current C++/SQLite client, Python/SQLAlchemy server
 - Fix display of "How much..." options in EDE-Q so that they fit on to an
   iPad screen in portrait.
   https://github.com/ucam-department-of-psychiatry/camcops/issues/287
+
+- Fix display of visual analogue scale in EQ-5D-5L in landscape on iPad
+  (and portrait on smaller screens) so that all of the scale is visible.
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/126
+
+- Fix clipping of topmost and bottommost Thermometer widget labels when the
+  text is greater in height than the images.

--- a/tablet_qt/menu/widgettestmenu.cpp
+++ b/tablet_qt/menu/widgettestmenu.cpp
@@ -699,6 +699,7 @@ void WidgetTestMenu::testThermometer()
         true,  // rescale
         0.25,  // rescale_factor
         4,  // text_gap_px
+        20, // top image offset px
         nullptr  // parent
     );
     debugfunc::debugWidget(widget);

--- a/tablet_qt/questionnairelib/quthermometer.cpp
+++ b/tablet_qt/questionnairelib/quthermometer.cpp
@@ -27,7 +27,7 @@
 #include "widgets/thermometer.h"
 
 const int DEFAULT_TEXT_GAP_PX = 5;
-const int DEFAULT_TOP_IMAGE_OFFSET_PX = 20;
+const int DEFAULT_IMAGE_PADDING_PX = 20;
 
 QuThermometer::QuThermometer(FieldRefPtr fieldref,
                              const QVector<QuThermometerItem>& items,
@@ -98,7 +98,7 @@ QPointer<QWidget> QuThermometer::makeWidget(Questionnaire* questionnaire)
         m_rescale,  // rescale
         m_rescale_factor,  // rescale_factor
         DEFAULT_TEXT_GAP_PX,  // text_gap_px
-        DEFAULT_TOP_IMAGE_OFFSET_PX,
+        DEFAULT_IMAGE_PADDING_PX,
         nullptr  // parent
     );
 

--- a/tablet_qt/questionnairelib/quthermometer.cpp
+++ b/tablet_qt/questionnairelib/quthermometer.cpp
@@ -27,7 +27,7 @@
 #include "widgets/thermometer.h"
 
 const int DEFAULT_TEXT_GAP_PX = 5;
-
+const int DEFAULT_TOP_IMAGE_OFFSET_PX = 20;
 
 QuThermometer::QuThermometer(FieldRefPtr fieldref,
                              const QVector<QuThermometerItem>& items,
@@ -98,6 +98,7 @@ QPointer<QWidget> QuThermometer::makeWidget(Questionnaire* questionnaire)
         m_rescale,  // rescale
         m_rescale_factor,  // rescale_factor
         DEFAULT_TEXT_GAP_PX,  // text_gap_px
+        DEFAULT_TOP_IMAGE_OFFSET_PX,
         nullptr  // parent
     );
 

--- a/tablet_qt/tasks/eq5d5l.cpp
+++ b/tablet_qt/tasks/eq5d5l.cpp
@@ -250,7 +250,10 @@ OpenableWidget* Eq5d5l::editor(const bool read_only)
 
     auto therm = new QuThermometer(fr_vas, items);
     // ... will be owned by the grid when inserted;
-    therm->setRescale(true, 0.4, true);
+    const double unscaled_height = 3200.0;
+    const double rescale_factor = uifunc::screenHeight() / unscaled_height;
+
+    therm->setRescale(true, rescale_factor, true);
 
     const bool allow_scroll = false;
     const bool zoomable = false;

--- a/tablet_qt/widgets/thermometer.cpp
+++ b/tablet_qt/widgets/thermometer.cpp
@@ -96,7 +96,7 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
                          bool rescale_images,
                          double rescale_image_factor,
                          int text_gap_px,
-                         int top_image_offset_px,
+                         int image_padding_px,
                          QWidget* parent) :
     QWidget(parent),
     m_active_images(active_images),
@@ -112,7 +112,7 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
     m_rescale_images(rescale_images),
     m_rescale_image_factor(rescale_image_factor),
     m_text_gap_px(text_gap_px),
-    m_top_image_offset_px(top_image_offset_px),
+    m_image_padding_px(image_padding_px),
     // m_unused_space_colour(QColor()),
     m_selected_index(UNSELECTED),
     m_touching_index(UNSELECTED),
@@ -197,8 +197,8 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
     // Set up layout: vertical.
     // Also create "being touched" images.
     // ------------------------------------------------------------------------
-    const int top_offset = m_top_image_offset_px;
-    const qreal scaled_top_offset = imageScale(top_offset);
+    const int image_padding = m_image_padding_px;
+    const qreal scaled_image_padding = imageScale(image_padding);
 
     const bool pressed_marker_behind = false;  // colour on top
     for (int i = 0; i < m_n_rows; ++i) {
@@ -207,10 +207,10 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
         const int unscaled_height = active_image.height();
         const qreal scaled_height = imageScale(unscaled_height);
         if (i == 0) {
-            m_raw_image_tops.append(top_offset);
+            m_raw_image_tops.append(image_padding);
             m_image_top_bottom.append(
                 QPair<qreal, qreal>(
-                    scaled_top_offset, scaled_top_offset + scaled_height
+                    scaled_image_padding, scaled_image_padding + scaled_height
                 )
             );
         } else {
@@ -253,7 +253,7 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
             uifunc::addPressedBackground(inactive_image, pressed_marker_behind));
     }
     m_target_total_size.rheight() = qCeil(
-        m_image_top_bottom[m_n_rows - 1].second + scaled_top_offset);
+        m_image_top_bottom[m_n_rows - 1].second + scaled_image_padding);
 
     // ------------------------------------------------------------------------
     // Final layout calculations

--- a/tablet_qt/widgets/thermometer.cpp
+++ b/tablet_qt/widgets/thermometer.cpp
@@ -96,6 +96,7 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
                          bool rescale_images,
                          double rescale_image_factor,
                          int text_gap_px,
+                         int top_image_offset_px,
                          QWidget* parent) :
     QWidget(parent),
     m_active_images(active_images),
@@ -111,6 +112,7 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
     m_rescale_images(rescale_images),
     m_rescale_image_factor(rescale_image_factor),
     m_text_gap_px(text_gap_px),
+    m_top_image_offset_px(top_image_offset_px),
     // m_unused_space_colour(QColor()),
     m_selected_index(UNSELECTED),
     m_touching_index(UNSELECTED),
@@ -195,6 +197,8 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
     // Set up layout: vertical.
     // Also create "being touched" images.
     // ------------------------------------------------------------------------
+    const int top_offset = m_top_image_offset_px;
+    const qreal scaled_top_offset = imageScale(top_offset);
 
     const bool pressed_marker_behind = false;  // colour on top
     for (int i = 0; i < m_n_rows; ++i) {
@@ -203,8 +207,12 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
         const int unscaled_height = active_image.height();
         const qreal scaled_height = imageScale(unscaled_height);
         if (i == 0) {
-            m_raw_image_tops.append(0);
-            m_image_top_bottom.append(QPair<qreal, qreal>(0, scaled_height));
+            m_raw_image_tops.append(top_offset);
+            m_image_top_bottom.append(
+                QPair<qreal, qreal>(
+                    scaled_top_offset, scaled_top_offset + scaled_height
+                )
+            );
         } else {
             m_raw_image_tops.append(
                         m_raw_image_tops[i - 1] +
@@ -245,7 +253,7 @@ Thermometer::Thermometer(const QVector<QPixmap>& active_images,
             uifunc::addPressedBackground(inactive_image, pressed_marker_behind));
     }
     m_target_total_size.rheight() = qCeil(
-                m_image_top_bottom[m_n_rows - 1].second);
+        m_image_top_bottom[m_n_rows - 1].second + scaled_top_offset);
 
     // ------------------------------------------------------------------------
     // Final layout calculations

--- a/tablet_qt/widgets/thermometer.h
+++ b/tablet_qt/widgets/thermometer.h
@@ -69,6 +69,12 @@ class Thermometer : public QWidget
         [5] m_rstring_left
         [6]
 
+    left_text and right_text are vertically aligned with the centre of each
+    image. The images may well be shorter vertically than the text label. To
+    prevent the labels at the top and bottom from being clipped, the images may
+    be padded with image_padding_px (m_image_padding_px). The padding is
+    included when calculating the total height of the widget.
+
     Widths:
         [a] m_lstring_width;
             left_string_span / (left_string_span + image_span + right_string_span)
@@ -98,7 +104,7 @@ public:
             bool rescale_images = false,  // rescale from images' intrinsic size?
             double rescale_image_factor = 1.0,  // if rescale: scale factor
             int text_gap_px = 4,  // gap between images and adjacent text
-            int top_image_offset_px = 0,
+            int image_padding_px = 0,
             QWidget* parent = nullptr);
 
     // ------------------------------------------------------------------------
@@ -188,7 +194,7 @@ protected:
     bool m_rescale_images;  // rescale images?
     double m_rescale_image_factor;  // if rescale: by what factor?
     int m_text_gap_px;  // gap between images and adjacent text
-    int m_top_image_offset_px;
+    int m_image_padding_px;  // gap above and below the stack of images
     // QColor m_unused_space_colour;  // colour for any "unpainted" area
 
     // Details of the current selection:

--- a/tablet_qt/widgets/thermometer.h
+++ b/tablet_qt/widgets/thermometer.h
@@ -98,6 +98,7 @@ public:
             bool rescale_images = false,  // rescale from images' intrinsic size?
             double rescale_image_factor = 1.0,  // if rescale: scale factor
             int text_gap_px = 4,  // gap between images and adjacent text
+            int top_image_offset_px = 0,
             QWidget* parent = nullptr);
 
     // ------------------------------------------------------------------------
@@ -187,6 +188,7 @@ protected:
     bool m_rescale_images;  // rescale images?
     double m_rescale_image_factor;  // if rescale: by what factor?
     int m_text_gap_px;  // gap between images and adjacent text
+    int m_top_image_offset_px;
     // QColor m_unused_space_colour;  // colour for any "unpainted" area
 
     // Details of the current selection:


### PR DESCRIPTION
I've changed the QuThermometer scale factor in the EQ-5D-5L task to be calculated from the screen height. It won't auto-resize on orientation change (I've found it to be buggy in the past). I'll revisit this when we move to Qt6.

I've also added 20px (scaled) padding to the top and bottom images of the thermometer to stop clipping the top and bottom numbers. We might want to make this configurable in the future.
