### PR TITLE
Updates for SQLAlchemy 1.4

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3815,3 +3815,6 @@ Current C++/SQLite client, Python/SQLAlchemy server
   would see a generic error message and the only way to fix it was to re-register
   the patient.
   https://github.com/ucam-department-of-psychiatry/camcops/issues/263
+
+- Supported SQLAlchemy version now 1.4
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/172

--- a/server/camcops_server/cc_modules/cc_export.py
+++ b/server/camcops_server/cc_modules/cc_export.py
@@ -194,8 +194,7 @@ from pendulum import DateTime as Pendulum, Duration, Period
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.renderers import render_to_response
 from pyramid.response import Response
-from sqlalchemy.engine import create_engine
-from sqlalchemy.engine.result import ResultProxy
+from sqlalchemy.engine import create_engine, CursorResult
 from sqlalchemy.orm import Session as SqlASession, sessionmaker
 from sqlalchemy.sql.expression import text
 from sqlalchemy.sql.schema import Column, MetaData, Table
@@ -652,7 +651,7 @@ def gen_audited_tasks_by_task_class(
             yield task
 
 
-def get_information_schema_query(req: "CamcopsRequest") -> ResultProxy:
+def get_information_schema_query(req: "CamcopsRequest") -> CursorResult:
     """
     Returns an SQLAlchemy query object that fetches the
     INFORMATION_SCHEMA.COLUMNS information from our source database.
@@ -682,8 +681,8 @@ def get_information_schema_spreadsheet_page(
     Returns the server database's ``INFORMATION_SCHEMA.COLUMNS`` table as a
     :class:`camcops_server.cc_modules.cc_spreadsheet.SpreadsheetPage``.
     """
-    result_proxy = get_information_schema_query(req)
-    return SpreadsheetPage.from_resultproxy(page_name, result_proxy)
+    result = get_information_schema_query(req)
+    return SpreadsheetPage.from_result(page_name, result)
 
 
 def write_information_schema_to_dst(

--- a/server/camcops_server/cc_modules/cc_exportmodels.py
+++ b/server/camcops_server/cc_modules/cc_exportmodels.py
@@ -281,11 +281,19 @@ class ExportedTask(Base):
 
     recipient = relationship(ExportRecipient)
 
-    emails = relationship("ExportedTaskEmail")
-    fhir_exports = relationship("ExportedTaskFhir")
-    filegroups = relationship("ExportedTaskFileGroup")
-    hl7_messages = relationship("ExportedTaskHL7Message")
-    redcap_exports = relationship("ExportedTaskRedcap")
+    emails = relationship("ExportedTaskEmail", back_populates="exported_task")
+    fhir_exports = relationship(
+        "ExportedTaskFhir", back_populates="exported_task"
+    )
+    filegroups = relationship(
+        "ExportedTaskFileGroup", back_populates="exported_task"
+    )
+    hl7_messages = relationship(
+        "ExportedTaskHL7Message", back_populates="exported_task"
+    )
+    redcap_exports = relationship(
+        "ExportedTaskRedcap", back_populates="exported_task"
+    )
 
     def __init__(
         self,
@@ -1299,7 +1307,9 @@ class ExportedTaskFhir(Base):
 
     exported_task = relationship(ExportedTask)
 
-    entries = relationship("ExportedTaskFhirEntry")
+    entries = relationship(
+        "ExportedTaskFhirEntry", back_populates="exported_task_fhir"
+    )
 
     def __init__(self, exported_task: ExportedTask = None) -> None:
         """

--- a/server/camcops_server/cc_modules/cc_group.py
+++ b/server/camcops_server/cc_modules/cc_group.py
@@ -152,6 +152,7 @@ class Group(Base):
         "Group.id==UserGroupMembership.group_id, "
         "User.id==UserGroupMembership.user_id, "
         "User.auto_generated==False)",
+        viewonly=True,
     )
     regular_users = association_proxy("regular_user_group_memberships", "user")
 

--- a/server/camcops_server/cc_modules/cc_report.py
+++ b/server/camcops_server/cc_modules/cc_report.py
@@ -55,7 +55,7 @@ from deform.form import Form
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.renderers import render_to_response
 from pyramid.response import Response
-from sqlalchemy.engine.result import ResultProxy
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.expression import and_, column, func, select
@@ -472,7 +472,7 @@ class Report(object):
         """
         statement = self.get_query(req)
         if statement is not None:
-            rp = req.dbsession.execute(statement)  # type: ResultProxy
+            rp = req.dbsession.execute(statement)  # type: CursorResult
             column_names = rp.keys()
             rows = rp.fetchall()
 

--- a/server/camcops_server/cc_modules/cc_spreadsheet.py
+++ b/server/camcops_server/cc_modules/cc_spreadsheet.py
@@ -60,7 +60,7 @@ from cardinal_pythonlib.excel import (
     convert_for_pyexcel_ods3,
 )
 from cardinal_pythonlib.logs import BraceStyleAdapter
-from sqlalchemy.engine.result import ResultProxy
+from sqlalchemy.engine import CursorResult
 
 from camcops_server.cc_modules.cc_constants import DateFormat
 
@@ -135,13 +135,13 @@ class SpreadsheetPage(object):
         return page
 
     @classmethod
-    def from_resultproxy(cls, name: str, rp: ResultProxy) -> "SpreadsheetPage":
+    def from_result(cls, name: str, rp: CursorResult) -> "SpreadsheetPage":
         """
-        Creates a SpreadsheetPage object from an SQLAlchemy ResultProxy.
+        Creates a SpreadsheetPage object from an SQLAlchemy Result.
 
         Args:
             rp:
-                A :class:` sqlalchemy.engine.result.ResultProxy`.
+                A :class:` sqlalchemy.engine.Result`.
             name:
                 Name for this sheet.
         """

--- a/server/camcops_server/cc_modules/cc_sqla_coltypes.py
+++ b/server/camcops_server/cc_modules/cc_sqla_coltypes.py
@@ -1209,6 +1209,9 @@ class UuidColType(TypeDecorator):
     def process_bind_param(
         self, value: uuid.UUID, dialect: Dialect
     ) -> Optional[str]:
+        """
+        Convert parameters on the way from Python to the database.
+        """
         if value is None:
             return None
 
@@ -1217,6 +1220,9 @@ class UuidColType(TypeDecorator):
     def process_result_value(
         self, value: Optional[str], dialect: Dialect
     ) -> Optional[uuid.UUID]:
+        """
+        Convert things on the way from the database to Python.
+        """
         if value is None:
             return None
 
@@ -1243,12 +1249,18 @@ class JsonColType(TypeDecorator):
     def process_bind_param(
         self, value: Any, dialect: Dialect
     ) -> Optional[str]:
+        """
+        Convert parameters on the way from Python to the database.
+        """
         if value is None:
             return None
 
         return json.dumps(value)
 
     def process_result_value(self, value: str, dialect: Dialect) -> Any:
+        """
+        Convert things on the way from the database to Python.
+        """
         if value is None:
             return None
 
@@ -1272,6 +1284,9 @@ class PhoneNumberColType(TypeDecorator):
     def process_bind_param(
         self, value: Any, dialect: Dialect
     ) -> Optional[str]:
+        """
+        Convert parameters on the way from Python to the database.
+        """
         if value is None:
             return None
 
@@ -1280,6 +1295,9 @@ class PhoneNumberColType(TypeDecorator):
         )
 
     def process_result_value(self, value: str, dialect: Dialect) -> Any:
+        """
+        Convert things on the way from the database to Python.
+        """
         if not value:
             return None
 

--- a/server/camcops_server/cc_modules/cc_sqla_coltypes.py
+++ b/server/camcops_server/cc_modules/cc_sqla_coltypes.py
@@ -352,6 +352,7 @@ class isotzdatetime_to_utcdatetime(FunctionElement):
 
     type = DateTime()
     name = "isotzdatetime_to_utcdatetime"
+    inherit_cache = False
 
 
 # noinspection PyUnusedLocal
@@ -592,6 +593,7 @@ class unknown_field_to_utcdatetime(FunctionElement):
 
     type = DateTime()
     name = "unknown_field_to_utcdatetime"
+    inherit_cache = False
 
 
 # noinspection PyUnusedLocal
@@ -684,6 +686,8 @@ class PendulumDateTimeAsIsoTextColType(TypeDecorator):
 
     impl = String(length=StringLengths.ISO8601_DATETIME_STRING_MAX_LEN)
     # ... underlying SQL type
+
+    cache_ok = False
 
     _coltype_name = "PendulumDateTimeAsIsoTextColType"
 
@@ -847,6 +851,8 @@ class PendulumDurationAsIsoTextColType(TypeDecorator):
     impl = String(length=StringLengths.ISO8601_DURATION_STRING_MAX_LEN)
     # ... underlying SQL type
 
+    cache_ok = False
+
     _coltype_name = "PendulumDurationAsIsoTextColType"
 
     @property
@@ -953,6 +959,8 @@ class SemanticVersionColType(TypeDecorator):
     """
 
     impl = String(length=147)  # https://github.com/mojombo/semver/issues/79
+
+    cache_ok = False
 
     _coltype_name = "SemanticVersionColType"
 
@@ -1192,6 +1200,8 @@ class UuidColType(TypeDecorator):
 
     impl = CHAR(32)
 
+    cache_ok = False
+
     @property
     def python_type(self) -> type:
         return str
@@ -1224,6 +1234,8 @@ class JsonColType(TypeDecorator):
     # does not use vendor-specific JSON type
     impl = UnicodeText
 
+    cache_ok = False
+
     @property
     def python_type(self) -> type:
         return str
@@ -1250,6 +1262,8 @@ class JsonColType(TypeDecorator):
 
 class PhoneNumberColType(TypeDecorator):
     impl = Unicode(length=StringLengths.PHONE_NUMBER_MAX_LEN)
+
+    cache_ok = False
 
     @property
     def python_type(self) -> type:

--- a/server/camcops_server/cc_modules/cc_sqlalchemy.py
+++ b/server/camcops_server/cc_modules/cc_sqlalchemy.py
@@ -74,8 +74,9 @@ from pendulum import DateTime as Pendulum
 
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.base import Engine
-from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
+from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.ext.mutable import Mutable
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.schema import CreateTable
 from sqlalchemy.sql.schema import MetaData, Table
 

--- a/server/camcops_server/cc_modules/cc_taskreports.py
+++ b/server/camcops_server/cc_modules/cc_taskreports.py
@@ -38,7 +38,7 @@ from cardinal_pythonlib.sqlalchemy.orm_query import (
     get_rows_fieldnames_from_query,
 )
 from cardinal_pythonlib.sqlalchemy.sqlfunc import extract_month, extract_year
-from sqlalchemy.engine.result import RowProxy
+from sqlalchemy.engine import Row
 from sqlalchemy.sql.elements import UnaryExpression
 from sqlalchemy.sql.expression import desc, func, literal, select
 from sqlalchemy.sql.functions import FunctionElement
@@ -274,7 +274,7 @@ class TaskCountReport(Report):
                 if by_task:
                     final_rows.extend(rows)
                 else:
-                    for row in rows:  # type: RowProxy
+                    for row in rows:  # type: Row
                         key = tuple(row[keyname] for keyname in groupers)
                         count = row[label_n]
                         counter.update({key: count})

--- a/server/camcops_server/cc_modules/client_api.py
+++ b/server/camcops_server/cc_modules/client_api.py
@@ -369,7 +369,7 @@ from pyramid.view import view_config
 from pyramid.response import Response
 from pyramid.security import NO_PERMISSION_REQUIRED
 from semantic_version import Version
-from sqlalchemy.engine.result import ResultProxy
+from sqlalchemy.engine.result import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import exists, select, update
@@ -1278,9 +1278,9 @@ def flag_all_records_deleted(req: "CamcopsRequest", table: Table) -> int:
         .where(table.c[FN_CURRENT])
         .where(table.c[FN_ERA] == ERA_NOW)
         .values(values_delete_later())
-    )  # type: ResultProxy
+    )  # type: CursorResult
     return rp.rowcount
-    # https://docs.sqlalchemy.org/en/latest/core/connections.html?highlight=rowcount#sqlalchemy.engine.ResultProxy.rowcount  # noqa
+    # https://docs.sqlalchemy.org/en/latest/core/connections.html?highlight=rowcount#sqlalchemy.engine.Result.rowcount  # noqa
 
 
 def flag_deleted_where_clientpk_not(
@@ -1301,7 +1301,7 @@ def flag_deleted_where_clientpk_not(
         .where(table.c[FN_ERA] == ERA_NOW)
         .where(table.c[clientpk_name].notin_(clientpk_values))
         .values(values_delete_later())
-    )  # type: ResultProxy
+    )  # type: CursorResult
     if rp.rowcount > 0:
         mark_table_dirty(req, table)
     # ... but if we are preserving, do NOT mark this table as clean; there may
@@ -1686,7 +1686,7 @@ def insert_record(
         valuedict.update({FN_CURRENT: 0, FN_ADDITION_PENDING: 1})
     rp = req.dbsession.execute(
         table.insert().values(valuedict)
-    )  # type: ResultProxy
+    )  # type: CursorResult
     inserted_pks = rp.inserted_primary_key
     assert isinstance(inserted_pks, list) and len(inserted_pks) == 1
     return inserted_pks[0]

--- a/server/camcops_server/cc_modules/client_api.py
+++ b/server/camcops_server/cc_modules/client_api.py
@@ -369,7 +369,7 @@ from pyramid.view import view_config
 from pyramid.response import Response
 from pyramid.security import NO_PERMISSION_REQUIRED
 from semantic_version import Version
-from sqlalchemy.engine.result import CursorResult
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import exists, select, update

--- a/server/camcops_server/cc_modules/merge_db.py
+++ b/server/camcops_server/cc_modules/merge_db.py
@@ -86,7 +86,7 @@ from camcops_server.cc_modules.cc_user import (
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.engine.result import ResultProxy
+    from sqlalchemy.engine import CursorResult
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 
@@ -771,7 +771,7 @@ def translate_fn(trcon: TranslationContext) -> None:
             .where(column(Patient._device_id.name) == old_patient._device_id)
             .where(column(Patient._era.name) == old_patient._era)
         )
-        rows = trcon.src_session.execute(src_pt_query)  # type: ResultProxy
+        rows = trcon.src_session.execute(src_pt_query)  # type: CursorResult
         list_of_dicts = [dict(row.items()) for row in rows]
         assert (
             len(list_of_dicts) == 1

--- a/server/camcops_server/pytest.ini
+++ b/server/camcops_server/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict --tb=short
+addopts = --strict-markers --tb=short
 python_classes = *Tests
 python_files = *tests.py
 norecursedirs =

--- a/server/setup.py
+++ b/server/setup.py
@@ -103,7 +103,7 @@ INSTALL_REQUIRES = [
     "pdfkit==1.0.0",  # wkhtmltopdf interface, for PDF generation from HTML
     "phonenumbers==8.12.30",  # phone number parsing, storing and validating
     "pycap==1.1.1",  # REDCap integration
-    "Pillow==9.3.0",  # used by a dependency; pin for security warnings
+    "Pillow==10.0.1",  # used by a dependency; pin for security warnings
     "Pygments==2.15.0",  # Syntax highlighting for introspection/DDL
     "pyexcel-ods3==0.6.0",  # ODS spreadsheet export
     "pyexcel-xlsx==0.6.0",  # XLSX spreadsheet export

--- a/server/setup.py
+++ b/server/setup.py
@@ -69,7 +69,7 @@ INSTALL_REQUIRES = [
     # -------------------------------------------------------------------------
     "alembic==1.4.2",  # database migrations
     "asteval==0.9.25",  # safe-ish alternative to eval
-    "cardinal_pythonlib==1.1.24",  # RNC libraries
+    "cardinal_pythonlib @ git+https://github.com/RudolfCardinal/pythonlib@ac01c533bf413c15621061a50a38610f0d48b8d4#egg=cardinal_pythonlib-1.1.25",  # RNC libraries  # noqa: E501
     "celery==5.2.2",  # background tasks
     "colander==1.7.0",  # serialization/deserialization from web forms
     "CherryPy==18.6.0",  # web server

--- a/server/setup.py
+++ b/server/setup.py
@@ -117,7 +117,7 @@ INSTALL_REQUIRES = [
     "sadisplay==0.4.9",  # SQL Alchemy schema display script
     "scipy==1.10.1",  # used by some tasks. slow installation.
     "semantic_version==2.8.5",  # semantic versioning; better than semver
-    "sqlalchemy==1.3.24",  # database access
+    "sqlalchemy==1.4.49",  # database access
     "statsmodels==0.13.5",  # e.g. logistic regression
     "twilio==7.9.3",  # SMS backend for Multi-factor authentication
     "urllib3==1.26.7",  # dependency, pinned to avoid vulnerabilities

--- a/server/setup.py
+++ b/server/setup.py
@@ -69,7 +69,7 @@ INSTALL_REQUIRES = [
     # -------------------------------------------------------------------------
     "alembic==1.4.2",  # database migrations
     "asteval==0.9.25",  # safe-ish alternative to eval
-    "cardinal_pythonlib @ git+https://github.com/RudolfCardinal/pythonlib@ac01c533bf413c15621061a50a38610f0d48b8d4#egg=cardinal_pythonlib-1.1.25",  # RNC libraries  # noqa: E501
+    "cardinal_pythonlib==1.1.25",  # RNC libraries
     "celery==5.2.2",  # background tasks
     "colander==1.7.0",  # serialization/deserialization from web forms
     "CherryPy==18.6.0",  # web server

--- a/server/setup.py
+++ b/server/setup.py
@@ -120,7 +120,7 @@ INSTALL_REQUIRES = [
     "sqlalchemy==1.4.49",  # database access
     "statsmodels==0.13.5",  # e.g. logistic regression
     "twilio==7.9.3",  # SMS backend for Multi-factor authentication
-    "urllib3==1.26.7",  # dependency, pinned to avoid vulnerabilities
+    "urllib3==1.26.17",  # dependency, pinned to avoid vulnerabilities
     "Wand==0.6.1",  # ImageMagick binding
     # -------------------------------------------------------------------------
     # Not installed here


### PR DESCRIPTION
Most of the changes are in cardinal_pythonlib 1.1.25. 

The changes to CamCOPS itself fix type hints and deprecation warnings. 

I'll leave SQLAlchemy 2.0 for another day. The migration can be done in several steps as documented at https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#sqlalchemy-2-0-major-migration-guide 

Also fixes some python packages and a pytest deprecation warning.

Fixes #172 

