### PR TITLE
Remove invalid assertion following SQLAlchemy 1.4 upgrade

### DIFF
--- a/server/camcops_server/cc_modules/client_api.py
+++ b/server/camcops_server/cc_modules/client_api.py
@@ -1688,7 +1688,6 @@ def insert_record(
         table.insert().values(valuedict)
     )  # type: CursorResult
     inserted_pks = rp.inserted_primary_key
-    assert isinstance(inserted_pks, list) and len(inserted_pks) == 1
     return inserted_pks[0]
 
 

--- a/server/setup.py
+++ b/server/setup.py
@@ -150,7 +150,7 @@ INSTALL_REQUIRES = [
     "prettytable==0.7.2",
     "psutil==5.7.0",
     "pyparsing==2.4.7",
-    "pypdf==3.9.0",  # Used by cardinal_pythonlib.pdf
+    "pypdf==3.17.0",  # Used by cardinal_pythonlib.pdf
     "python-dateutil==2.8.1",  # date/time extensions.
     "sqlparse==0.4.4",
     # extra

--- a/server/setup.py
+++ b/server/setup.py
@@ -120,7 +120,7 @@ INSTALL_REQUIRES = [
     "sqlalchemy==1.4.49",  # database access
     "statsmodels==0.13.5",  # e.g. logistic regression
     "twilio==7.9.3",  # SMS backend for Multi-factor authentication
-    "urllib3==1.26.17",  # dependency, pinned to avoid vulnerabilities
+    "urllib3==1.26.18",  # dependency, pinned to avoid vulnerabilities
     "Wand==0.6.1",  # ImageMagick binding
     # -------------------------------------------------------------------------
     # Not installed here


### PR DESCRIPTION
I missed this when upgrading to SQL Alchemy 1.4

Since SQLAlchemy 1.4, the return value from Session.execute() is now a CursorResult object and the type of
CursorResult.inserted_primary_key is now a tuple, not a list.

@RudolfCardinal the assert was added in 04599ca928a5d66da732598c55503986abda18da. I don't suppose you remember why? I suppose we could keep the `len(inserted_pks) == 1` if we wanted.

Old docs:
https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.ResultProxy.inserted_primary_key
New docs:
https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.CursorResult.inserted_primary_key
