### PR TITLE
Ensure the upload icon stays visible when an upload fails with the log box visible

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3883,3 +3883,7 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 - Additional optional LGPL licensing for some Qt height-for-width layout code
   to make it suitable for inclusion in libraries elsewhere.
+
+- Fix bug where the upload icon would remain visible if the activity log were enabled and
+  the upload failed.
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/341

--- a/tablet_qt/core/camcopsapp.cpp
+++ b/tablet_qt/core/camcopsapp.cpp
@@ -3202,14 +3202,14 @@ void CamcopsApp::upload()
         return;
     }
 
-    const bool single_user_mode = isSingleUserMode();
+    const bool logging_network = isLoggingNetwork();
     reconnectNetManager(
-                single_user_mode ? &CamcopsApp::uploadFailed : nullptr,
-                single_user_mode ? &CamcopsApp::uploadFinished : nullptr);
-    // ... no failure handlers required in clinician mode -- the NetworkManager
-    // will not be in silent mode, so will report the error to the user
-    // directly. (And similarly, we didn't/don't need a "finished" callback in
-    // clinician mode.)
+                logging_network ? nullptr : &CamcopsApp::uploadFailed,
+                logging_network ? nullptr : &CamcopsApp::uploadFinished);
+    // ... no failure handlers required when displaying the network log --
+    // the NetworkManager will not be in silent mode, so will report the error
+    // to the user directly. (And similarly, we didn't/don't need a "finished"
+    // callback in with the logbox enabled.)
 
     showNetworkGuiGuard(tr("Uploading..."));
     networkManager()->upload(method);


### PR DESCRIPTION
Fixes #341 

Prior to this fix, in single user mode, with the network activity log enabled, the upload icon would disappear if the upload failed. This is now fixed by only enabling the network manager success/failure callbacks when the log is disabled (the default for single user mode). The log is always enabled in clinician mode.
