### PR TITLE
Fix undefined behaviour when a task in a chain is prohibited and a subwindow is closed

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3900,3 +3900,7 @@ Current C++/SQLite client, Python/SQLAlchemy server
   has forgotten their password. Fix a bug where if the initial password dialog was
   aborted, the next attempt to set up a password would fail.
   https://github.com/ucam-department-of-psychiatry/camcops/issues/346
+
+- Fix undefined behaviour if a task in a taskchain was aborted due to e.g. a missing
+  IP setting. Sometimes the tasks would be displayed if the back button was pressed.
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/350

--- a/tablet_qt/tasklib/taskchain.cpp
+++ b/tablet_qt/tasklib/taskchain.cpp
@@ -189,6 +189,8 @@ void TaskChain::start()
 
 void TaskChain::startNextTask()
 {
+    m_proceed_when_app_has_closed_last_task = false;
+
     // Move to next task
     ++m_current_task_index;
     // All done?
@@ -219,7 +221,6 @@ void TaskChain::startNextTask()
             << ": " << ptask->shortname();
 
     // Launch the task
-    m_proceed_when_app_has_closed_last_task = false;
     m_app.openSubWindow(widget, task, true);
 }
 

--- a/tablet_qt/tasklib/taskchain.cpp
+++ b/tablet_qt/tasklib/taskchain.cpp
@@ -38,7 +38,8 @@ TaskChain::TaskChain(CamcopsApp& app,
     m_creation_method(creation_method),
     m_title(title),
     m_subtitle(subtitle),
-    m_current_task_index(-1)
+    m_current_task_index(-1),
+    m_proceed_when_app_has_closed_last_task(false)
 {
     QObject::connect(&m_app, &CamcopsApp::subWindowFinishedClosing,
                      this, &TaskChain::onAppSubWindowClosed);


### PR DESCRIPTION
Fix uninitialised flag in `TaskChain` class

Fixes #350 (or part of it). If a task chain had been aborted because of a missing IP setting, pressing the back button would cause the tasks up to the prohibited one to be displayed.

This probably would also have failed in the same way if a patient hadn't been selected and the task chain required it. 