### PR TITLE
Fix the Qt build for Android 32 and 64-bit emulators

### DIFF
--- a/.github/workflows/python-package-checks.yml
+++ b/.github/workflows/python-package-checks.yml
@@ -32,8 +32,10 @@ jobs:
                   python -m pip install safety
                   echo checking packages for vulnerabilities
                   # All of these vulnerabilities look either harmless or very low risk
-                  # 51668 sqlalchemy fix in 2.0 beta, we don't log Engine.URL()
+                  # 51668 sqlalchemy. Fix in 2.0 beta. We don't log Engine.URL()
                   #       https://github.com/sqlalchemy/sqlalchemy/issues/8567
-                  # 52495 setuptools fix in 65.5.1, we'll be careful not to
+                  # 52495 setuptools. Fix in 65.5.1. We'll be careful not to
                   #       install malicious packages.
-                  safety check --full-report --ignore=51668 --ignore=52495
+                  # 67599 pip. Disputed and only relevant if using --extra-index-url,
+                  #       which we're not.
+                  safety check --full-report --ignore=51668 --ignore=52495 --ignore=67599

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3904,3 +3904,5 @@ Current C++/SQLite client, Python/SQLAlchemy server
 - Fix undefined behaviour if a task in a taskchain was aborted due to e.g. a missing
   IP setting. Sometimes the tasks would be displayed if the back button was pressed.
   https://github.com/ucam-department-of-psychiatry/camcops/issues/350
+
+- Fix the Qt build for 32-bit and 64-bit Android emulator.

--- a/docs/source/developer/_build_qt_help.txt
+++ b/docs/source/developer/_build_qt_help.txt
@@ -3,11 +3,12 @@ usage: build_qt.py [-h] [--show_config_only] [--root_dir ROOT_DIR]
                    [--force] [--force_ffmpeg] [--force_openssl] [--force_qt]
                    [--force_sqlcipher] [--tee TEE] [--verbose {0,1,2}]
                    [--inherit_os_env] [--no_inherit_os_env] [--build_all]
-                   [--build_android_x86_32] [--build_android_arm_v7_32]
-                   [--build_android_arm_v8_64] [--build_linux_x86_64]
-                   [--build_macos_x86_64] [--build_windows_x86_64]
-                   [--build_windows_x86_32] [--build_ios_arm_v7_32]
-                   [--build_ios_arm_v8_64] [--build_ios_simulator_x86_32]
+                   [--build_android_x86_32] [--build_android_x86_64]
+                   [--build_android_arm_v7_32] [--build_android_arm_v8_64]
+                   [--build_linux_x86_64] [--build_macos_x86_64]
+                   [--build_windows_x86_64] [--build_windows_x86_32]
+                   [--build_ios_arm_v7_32] [--build_ios_arm_v8_64]
+                   [--build_ios_simulator_x86_32]
                    [--build_ios_simulator_x86_64]
                    [--qt_build_type {debug,release,release_w_symbols}]
                    [--qt_src_dirname QT_SRC_DIRNAME] [--qt_openssl_static]
@@ -57,6 +58,9 @@ Architecture:
   --build_android_x86_32
                         An architecture target (Android under an Intel x86
                         32-bit emulator) (default: False)
+  --build_android_x86_64
+                        An architecture target (Android under an Intel x86
+                        64-bit emulator) (default: False)
   --build_android_arm_v7_32
                         An architecture target (Android with a 32-bit ARM
                         processor) (default: False)

--- a/docs/source/developer/building_client.rst
+++ b/docs/source/developer/building_client.rst
@@ -536,7 +536,7 @@ Non-default options are marked in bold and/or as "[non-default]".
             ``-DCMAKE_C_COMPILER:FILEPATH=%{Compiler:Executable:C}``
             ``-DCMAKE_CXX_COMPILER:FILEPATH=%{Compiler:Executable:Cxx}``
 
-**Custom_Android_x86** -- NOT FULLY TESTED
+**Custom_Android_x86**
 
     .. list-table::
         :header-rows: 1
@@ -548,32 +548,80 @@ Non-default options are marked in bold and/or as "[non-default]".
           - **[non-default]** ``Custom_Android_x86``
         * - File system name
           -
-        * - Device type
+        * - Run device type
           - Android Device
-        * - Device
-          - Run on Android (default for Android)
-        * - Sysroot
-          -
+        * - Run device
+          - Pixel_3a_API_30_x86
+        * - Build device
+          - Desktop (default for Desktop)
         * - Compiler: C
-          - <No compiler>
+          - Android Clang (C, i686, NDK 25.1.8937393)
         * - Compiler: C++
-          - Android GCC (i686-4.9)
+          - Android Clang (C++, i686, NDK 25.1.8937393)
         * - Environment
           - [not editable: "No changes to apply."]
         * - Debugger
-          - Android Debugger for Android GCC (i686-4.9)
+          - Android Debugger (Multi-Abi, NDK 25.1.8937393)
+        * - Sysroot
+          -
         * - Qt version
           - **THE "ANDROID EMULATOR" ONE FROM QT VERSIONS, ABOVE**
         * - Qt mkspec
           -
-        * - CMake Tool
-          - System CMake at ``/usr/bin/cmake``
-        * - CMake Generator
-          - CodeBlocks - Unix Makefiles
-        * - CMake Configuration
-          - [not editable]
         * - Additional Qbs Profile Settings
           -
+        * - CMake Tool
+          - CMake 3.24.2 (Qt)
+        * - CMake Generator
+          - Ninja
+        * - CMake Configuration
+          - [not editable]
+        * - Python
+          - None
+
+**Custom_Android_x86_64**
+
+    .. list-table::
+        :header-rows: 1
+        :stub-columns: 1
+
+        * - Option
+          - Setting
+        * - Name
+          - **[non-default]** ``Custom_Android_x86_64``
+        * - File system name
+          -
+        * - Run device type
+          - Android Device
+        * - Run device
+          - Pixel_3a_API_34
+        * - Build device
+          - Desktop (default for Desktop)
+        * - Compiler: C
+          - Android Clang (C, x86_64, NDK 25.1.8937393)
+        * - Compiler: C++
+          - Android Clang (C++, x86_64, NDK 25.1.8937393)
+        * - Environment
+          - [not editable: "No changes to apply."]
+        * - Debugger
+          - Android Debugger (Multi-Abi, NDK 25.1.8937393)
+        * - Sysroot
+          -
+        * - Qt version
+          - **THE "ANDROID EMULATOR" ONE FROM QT VERSIONS, ABOVE**
+        * - Qt mkspec
+          -
+        * - Additional Qbs Profile Settings
+          -
+        * - CMake Tool
+          - CMake 3.24.2 (Qt)
+        * - CMake Generator
+          - Ninja
+        * - CMake Configuration
+          - [not editable]
+        * - Python
+          - None
+
 
 **Custom_Windows_x86_64**
 

--- a/docs/source/user_client/_camcops_client_help.txt
+++ b/docs/source/user_client/_camcops_client_help.txt
@@ -1,51 +1,34 @@
 Usage: /path/to/camcops/client/executable [options]
 
 Options:
-  -h, --help                                             Displays this help.
-  -v, --version                                          Displays version
-                                                         information.
-  --dbdir <DBDIR>                                        Specify the database
-                                                         directory, in which the
-                                                         databases
-                                                         "camcops_data.sqlite"
-                                                         and
-                                                         "camcops_sys.sqlite"
-                                                         are used or created.
-                                                         Order of precedence
-                                                         (highest to lowest) is
-                                                         (1) this argument, (2)
-                                                         the
-                                                         CAMCOPS_DATABASE_DIRECT
-                                                         ORY environment
-                                                         variable, and (3) the
-                                                         default, on this
-                                                         particular system, of
-                                                         "/path/to/client/databa
-                                                         se/dir".
-  --default_single_user_mode <DEFAULT_SINGLE_USER_MODE>  If no mode has
-                                                         previously been
-                                                         selected, do not
-                                                         display the mode
-                                                         selection dialog and
-                                                         default to single user
-                                                         mode.
-  --default_server_location <DEFAULT_SERVER_LOCATION>    If no server has been
-                                                         registered, default to
-                                                         this URL e.g.
-                                                         https://server.example.
-                                                         com/camcops/api
-  --default_access_key <DEFAULT_ACCESS_KEY>              If no patient has been
-                                                         registered, default to
-                                                         this access key e.g.
-                                                         abcde-fghij-klmno-pqrst
-                                                         -uvwxy-zabcd-efghi-jklm
-                                                         n-o
-  --print_icd9_codes                                     Print ICD-9-CM
-                                                         (DSM-IV) codes used by
-                                                         CamCOPS, and quit.
-  --print_icd10_codes                                    Print ICD-10 codes
-                                                         used by CamCOPS, and
-                                                         quit.
-  --print_terms_conditions                               Print terms and
-                                                         conditions applicable
-                                                         to CamCOPS, and quit.
+  -h, --help                         Displays help on commandline options.
+  --help-all                         Displays help including Qt specific
+                                     options.
+  -v, --version                      Displays version information.
+  --dbdir <DBDIR>                    Specify the database directory, in which
+                                     the databases "camcops_data.sqlite" and
+                                     "camcops_sys.sqlite" are used or created.
+                                     Order of precedence (highest to lowest) is
+                                     (1) this argument, (2) the
+                                     CAMCOPS_DATABASE_DIRECTORY environment
+                                     variable, and (3) the default, on this
+                                     particular system, of
+                                     "/path/to/client/database/dir".
+  --default_single_user_mode <MODE>  If no mode has previously been selected,
+                                     do not display the mode selection dialog
+                                     and default to single user mode.
+  --default_server_location <URL>    If no server has been registered, default
+                                     to this URL e.g.
+                                     https://server.example.com/camcops/api
+  --default_access_key <KEY>         If no patient has been registered, default
+                                     to this access key e.g.
+                                     abcde-fghij-klmno-pqrst-uvwxy-zabcd-efghi-j
+                                     klmn-o
+  --print_icd9_codes                 Print ICD-9-CM (DSM-IV) codes used by
+                                     CamCOPS, and quit.
+  --print_icd10_codes                Print ICD-10 codes used by CamCOPS, and
+                                     quit.
+  --print_tasks                      Print tasks supported in this version of
+                                     CamCOPS, and quit.
+  --print_terms_conditions           Print terms and conditions applicable to
+                                     CamCOPS, and quit.

--- a/server/setup.py
+++ b/server/setup.py
@@ -87,7 +87,7 @@ INSTALL_REQUIRES = [
     # FHIR export, our fork until https://github.com/smart-on-fhir/client-py/pull/105 is merged  # noqa
     "fhirclient @ git+https://github.com/ucam-department-of-psychiatry/client-py@128bbe3c2194a51ba6ff8cf880ef2fdb9bfcc2d6#egg=fhirclient-4.0.0.1",  # noqa: E501
     "flower==2.0.1",  # monitor for Celery
-    "gunicorn==21.2.0",  # web server (Unix only)
+    "gunicorn==22.0.0",  # web server (Unix only)
     "hl7==0.3.5",  # For HL7 export
     # Celery dependency for Python <= 3.7; workaround import error
     # https://github.com/celery/celery/issues/7783; scheduled to be fixed in

--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -301,8 +301,12 @@ android {
     CAMCOPS_OPENSSL_LINKAGE = "dynamic"
 
     contains(ANDROID_TARGET_ARCH, x86) {
-        message("Building for Android/x86 (e.g. Android emulator)")
-        CAMCOPS_ARCH_TAG = "android_x86"
+        message("Building for Android/x86_32 (e.g. Android emulator)")
+        CAMCOPS_ARCH_TAG = "android_x86_32"
+    }
+    contains(ANDROID_TARGET_ARCH, x86_64) {
+        message("Building for Android/x86_64 (e.g. Android emulator)")
+        CAMCOPS_ARCH_TAG = "android_x86_64"
     }
     contains(ANDROID_TARGET_ARCH, armeabi-v7a) {
         message("Building for Android/ARMv7 32-bit architecture")


### PR DESCRIPTION
Qt now builds for both x86 and x86_64 versions of the Android emulator.

Also fix one security alert and silence another.