### PR TITLE
Fix placement of cursor when entering access key on iOS

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3953,4 +3953,8 @@ Current C++/SQLite client, Python/SQLAlchemy server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Update the Docker image to use Debian 11. Debian 10 has now reached end-of-life.
+
 - **Minimum Python version now Python 3.9.** Python 3.11 and 3.12 supported.
+
+- Fix cursor placement when entering the access key on iOS. The workaround for
+  https://bugreports.qt.io/browse/QTBUG-115756 is now only applied for Android.

--- a/tablet_qt/widgets/proquintlineedit.cpp
+++ b/tablet_qt/widgets/proquintlineedit.cpp
@@ -40,7 +40,10 @@ void ProquintLineEdit::processChangedText()
     // Automatically strip white space and insert the dashes, because it's a
     // pain having to do that on a mobile on-screen keyboard
     auto line_edit = getLineEdit();
+
+#ifdef Q_OS_ANDROID
     line_edit->installEventFilter(this);
+#endif
 
     QString initial_text = line_edit->text();
 
@@ -70,17 +73,21 @@ void ProquintLineEdit::processChangedText()
 
     // Set text will put the cursor to the end so only set it if it has changed
     if (new_text != initial_text) {
+#ifdef Q_OS_ANDROID
         maybeIgnoreNextInputEvent();
+#endif
         line_edit->setText(new_text);
     }
 
     m_old_text = new_text;
 }
 
+#ifdef Q_OS_ANDROID
 // Thanks to Axel Spoerl for this workaround for
 // https://bugreports.qt.io/browse/QTBUG-115756
 // On Android, the cursor does not get updated properly if a dash is appended
-// Remove this when fixed.
+// Remove this when fixed (the change on that ticket was actually reverted due
+// to a regression elsewhere).
 bool ProquintLineEdit::eventFilter(QObject* obj, QEvent* event)
 {
     auto line_edit = getLineEdit();
@@ -104,3 +111,4 @@ void ProquintLineEdit::maybeIgnoreNextInputEvent()
         m_ignore_next_input_event = true;
     }
 }
+#endif

--- a/tablet_qt/widgets/proquintlineedit.h
+++ b/tablet_qt/widgets/proquintlineedit.h
@@ -41,10 +41,15 @@ public:
 
 protected:
     void processChangedText() override;
+#ifdef Q_OS_ANDROID
     bool eventFilter(QObject* obj, QEvent* event) override;
+#endif
 
 private:
     QString m_old_text;
+
+#ifdef Q_OS_ANDROID
     bool m_ignore_next_input_event = false;
     void maybeIgnoreNextInputEvent();
+#endif
 };


### PR DESCRIPTION
The workaround for https://bugreports.qt.io/browse/QTBUG-115756, which was applied in #312 should only have been applied for Android.