### PR TITLE
Don't treat warnings from Eigen as errors and client build workflow

### DIFF
--- a/.github/scripts/build_client.sh
+++ b/.github/scripts/build_client.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+echo "Building client..."
+echo "CAMCOPS_QT6_BASE_DIR=${CAMCOPS_QT6_BASE_DIR}"
+cd "${GITHUB_WORKSPACE}"
+
+QMAKE=${CAMCOPS_QT6_BASE_DIR}/qt_linux_x86_64_install/bin/qmake
+${QMAKE} -query
+
+BUILD_DIR=${GITHUB_WORKSPACE}/build-camcops-Linux_Qt6_5
+mkdir "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+${QMAKE} ../tablet_qt
+make

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -7,6 +7,7 @@ on:
         paths:
             - '**.cpp'
             - '**.h'
+            - tablet_qt/camcops.pro
             - .github/scripts/add_apt_sources.sh
             - .github/scripts/change_apt_mirror.sh
             - .github/scripts/build_client.sh

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,0 +1,62 @@
+---
+# yamllint disable rule:line-length
+name: Build client
+# yamllint disable-line rule:truthy
+on:
+    push:
+        paths:
+            - '**.cpp'
+            - '**.h'
+            - .github/scripts/add_apt_sources.sh
+            - .github/scripts/change_apt_mirror.sh
+            - .github/scripts/build_client.sh
+            - .github/workflows/build-client.yml
+jobs:
+    build-client:
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v4
+            - name: Download Qt
+              uses: dsaltares/fetch-gh-release-asset@1.1.2
+              with:
+                  # Can't do this from a different repo because the release
+                  # isn't public
+                  # Has to download to GITHUB_WORKSPACE
+                  file: qt.tgz
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  # The release ID is set by the build-qt.yml action
+                  # but the tagging is broken somehow. This is brittle
+                  # because editing the release on GitHub will change
+                  # the tag (which isn't a proper tag)
+                  version: 'tags/untagged-2ac5eb66666e2059a7e3'
+            - name: Install Qt
+              run: |
+                  set -euxo pipefail
+                  mv ${GITHUB_WORKSPACE}/qt.tgz ${HOME}
+                  cd ${HOME}
+                  ls
+                  # Remove home/runner from paths
+                  tar -xvzf qt.tgz --strip-components=2
+                  ls
+                  ls qt_local_build
+            - name: Ubuntu prerequisites
+              run: |
+                  set -euo pipefail
+                  ${GITHUB_WORKSPACE}/.github/scripts/change_apt_mirror.sh
+                  ${GITHUB_WORKSPACE}/.github/scripts/add_apt_sources.sh
+                  sudo apt-get -y install \
+                  libxcb-icccm4 \
+                  libxcb-xkb1 \
+                  libxcb-icccm4 \
+                  libxcb-image0 \
+                  libxcb-render-util0 \
+                  libxcb-randr0 \
+                  libxcb-keysyms1 \
+                  libxcb-xinerama0 \
+                  libxcb-xinput-dev \
+                  libxcb-cursor0
+            - name: Build client
+              run: |
+                  set -euo pipefail
+                  export CAMCOPS_QT6_BASE_DIR=${HOME}/qt_local_build
+                  xvfb-run --auto-servernum ${GITHUB_WORKSPACE}/.github/scripts/build_client.sh

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -60,4 +60,4 @@ jobs:
               run: |
                   set -euo pipefail
                   export CAMCOPS_QT6_BASE_DIR=${HOME}/qt_local_build
-                  xvfb-run --auto-servernum ${GITHUB_WORKSPACE}/.github/scripts/build_client.sh
+                  ${GITHUB_WORKSPACE}/.github/scripts/build_client.sh

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -46,7 +46,18 @@ jobs:
                   ${GITHUB_WORKSPACE}/.github/scripts/change_apt_mirror.sh
                   ${GITHUB_WORKSPACE}/.github/scripts/add_apt_sources.sh
                   sudo apt-get -y install \
+                  libcups2-dev \
+                  libdbus-1-dev \
+                  libdrm-dev \
+                  libegl1-mesa-dev \
                   libgl-dev \
+                  libharfbuzz-dev \
+                  libopengl-dev \
+                  libpulse-dev \
+                  libts-dev \
+                  libudev-dev \
+                  libvdpau-dev \
+                  libx11-xcb-dev \
                   libxcb-icccm4 \
                   libxcb-xkb1 \
                   libxcb-icccm4 \
@@ -55,8 +66,11 @@ jobs:
                   libxcb-randr0 \
                   libxcb-keysyms1 \
                   libxcb-xinerama0 \
-                  libxcb-xinput-dev \
-                  libxcb-cursor0
+                  libxcb-cursor0 \
+                  '^libxcb.*-dev' \
+                  libxkbcommon-dev \
+                  libxkbcommon-x11-dev \
+                  libxrandr-dev \
             - name: Build client
               run: |
                   set -euo pipefail

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -45,6 +45,7 @@ jobs:
                   ${GITHUB_WORKSPACE}/.github/scripts/change_apt_mirror.sh
                   ${GITHUB_WORKSPACE}/.github/scripts/add_apt_sources.sh
                   sudo apt-get -y install \
+                  libgl-dev \
                   libxcb-icccm4 \
                   libxcb-xkb1 \
                   libxcb-icccm4 \

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -221,6 +221,7 @@ jobs:
                   echo "Free space:"
                   df -h
                   tar -czvf /tmp/qt.tgz \
+                      ${HOME}/qt_local_build/eigen \
                       ${HOME}/qt_local_build/ffmpeg_linux_x86_64_build \
                       ${HOME}/qt_local_build/openssl_linux_x86_64_build \
                       ${HOME}/qt_local_build/qt_linux_x86_64_install \

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -33,7 +33,7 @@ jobs:
                   # but the tagging is broken somehow. This is brittle
                   # because editing the release on GitHub will change
                   # the tag (which isn't a proper tag)
-                  version: 'tags/untagged-de3656cacfe8d9840ad0'
+                  version: 'tags/untagged-2ac5eb66666e2059a7e3'
             - name: Install Qt
               run: |
                   set -euxo pipefail

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -24,7 +24,8 @@ jobs:
             - name: Download Qt
               uses: dsaltares/fetch-gh-release-asset@1.1.2
               with:
-                  repo: ucam-department-of-psychiatry/camcops
+                  # Can't do this from a different repo because the release
+                  # isn't public
                   # Has to download to GITHUB_WORKSPACE
                   file: qt.tgz
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -24,6 +24,7 @@ jobs:
             - name: Download Qt
               uses: dsaltares/fetch-gh-release-asset@1.1.2
               with:
+                  repo: ucam-department-of-psychiatry/camcops
                   # Has to download to GITHUB_WORKSPACE
                   file: qt.tgz
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-missing-client-translations.yml
+++ b/.github/workflows/report-missing-client-translations.yml
@@ -21,7 +21,8 @@ jobs:
             - name: Download Qt
               uses: dsaltares/fetch-gh-release-asset@1.1.2
               with:
-                  repo: ucam-department-of-psychiatry/camcops
+                  # Can't do this from a different repo because the release
+                  # isn't public
                   # Has to download to GITHUB_WORKSPACE
                   file: qt.tgz
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-missing-client-translations.yml
+++ b/.github/workflows/report-missing-client-translations.yml
@@ -30,7 +30,7 @@ jobs:
                   # but the tagging is broken somehow. This is brittle
                   # because editing the release on GitHub will change
                   # the tag (which isn't a proper tag)
-                  version: 'tags/untagged-de3656cacfe8d9840ad0'
+                  version: 'tags/untagged-2ac5eb66666e2059a7e3'
             - name: Install Qt
               run: |
                   set -euo pipefail

--- a/.github/workflows/report-missing-client-translations.yml
+++ b/.github/workflows/report-missing-client-translations.yml
@@ -21,6 +21,7 @@ jobs:
             - name: Download Qt
               uses: dsaltares/fetch-gh-release-asset@1.1.2
               with:
+                  repo: ucam-department-of-psychiatry/camcops
                   # Has to download to GITHUB_WORKSPACE
                   file: qt.tgz
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -251,11 +251,11 @@ QT_GIT_VERSION = $$replace(QT_GIT_VERSION, "-lts-lgpl", "")
 EIGEN_INCLUDE = "$${QT_BASE_DIR}/eigen/eigen-$${EIGEN_VERSION}"  # from which: <Eigen/...>
 
 gcc {
-  # Ignore Eigen warnings
-  # https://gitlab.com/libeigen/eigen/-/issues/2787
-  QMAKE_CXXFLAGS += "-isystem $${EIGEN_INCLUDE}"
-  } else {
-  INCLUDEPATH += "$${EIGEN_INCLUDE}"
+    # Ignore Eigen warnings
+    # https://gitlab.com/libeigen/eigen/-/issues/2787
+    QMAKE_CXXFLAGS += "-isystem $${EIGEN_INCLUDE}"
+} else {
+    INCLUDEPATH += "$${EIGEN_INCLUDE}"
 }
 
 

--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -259,11 +259,6 @@ gcc {
 }
 
 
-# INCLUDEPATH += "$${QT_BASE_DIR}/armadillo/armadillo-7.950.0/include"  # from which: <armadillo>
-# INCLUDEPATH += "$${QT_BASE_DIR}/armadillo/armadillo-7.950.0/include/armadillo_bits"
-# INCLUDEPATH += "$${QT_BASE_DIR}/boost/boost_1_64_0"  # from which: <boost/...>
-# INCLUDEPATH += "$${QT_BASE_DIR}/src/mlpack/src"  # from which: <mlpack/...>
-
 # =============================================================================
 # OS-specific options
 # =============================================================================

--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -247,7 +247,18 @@ QT_GIT_VERSION = $$replace(QT_GIT_VERSION, "-lts-lgpl", "")
     error("This version of CamCOPS should be built with '$${QT_GIT_VERSION}', not '$$[QT_VERSION]'")
 }
 
-INCLUDEPATH += "$${QT_BASE_DIR}/eigen/eigen-$${EIGEN_VERSION}"  # from which: <Eigen/...>
+
+EIGEN_INCLUDE = "$${QT_BASE_DIR}/eigen/eigen-$${EIGEN_VERSION}"  # from which: <Eigen/...>
+
+gcc {
+  # Ignore Eigen warnings
+  # https://gitlab.com/libeigen/eigen/-/issues/2787
+  QMAKE_CXXFLAGS += "-isystem $${EIGEN_INCLUDE}"
+  } else {
+  INCLUDEPATH += "$${EIGEN_INCLUDE}"
+}
+
+
 # INCLUDEPATH += "$${QT_BASE_DIR}/armadillo/armadillo-7.950.0/include"  # from which: <armadillo>
 # INCLUDEPATH += "$${QT_BASE_DIR}/armadillo/armadillo-7.950.0/include/armadillo_bits"
 # INCLUDEPATH += "$${QT_BASE_DIR}/boost/boost_1_64_0"  # from which: <boost/...>


### PR DESCRIPTION
See https://gitlab.com/libeigen/eigen/-/issues/2787 

Because we are treating warnings as errors the client build fails. 

Also a workflow to build the client on Ubuntu 22.04 using pre-built Qt release.
