### PR TITLE
Attempt to fix Google Play Store warnings 

### DIFF
--- a/docs/source/developer/play_store_release_history.csv
+++ b/docs/source/developer/play_store_release_history.csv
@@ -31,4 +31,4 @@ Google Play Store release name,AndroidManifest.xml version code,AndroidManifest.
 2.4.19,47 (32-bit ARM); 48 (64-bit ARM),2.4.19,2024-06-27,23,33
 2.4.20,49 (32-bit ARM); 50 (64-bit ARM),2.4.20,2024-08-14,23,34
 2.4.21,"N/A, server only",N/A,N/A,N/A,N/A
-2.4.22,51 (32-bit ARM); 52 (64-bit ARM),2.4.22,2025-07-16,23,34
+2.4.22,51 (32-bit ARM); 52 (64-bit ARM),2.4.22,2025-07-16,23,33

--- a/docs/source/developer/releasing.rst
+++ b/docs/source/developer/releasing.rst
@@ -105,6 +105,9 @@ Google Play Store settings
 Google Play Store release history
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The minimum and target SDK versions are specified in the ``camcops.pro`` project
+file. See ``ANDROID_MIN_SDK_VERSION`` and ``ANDROID_TARGET_SDK_VERSION``.
+
 .. csv-table::
    :file: play_store_release_history.csv
    :header-rows: 1

--- a/tablet_qt/android/build.gradle
+++ b/tablet_qt/android/build.gradle
@@ -76,8 +76,24 @@ android {
 
     defaultConfig {
         resConfig "en"
+        // Specified in camcops.pro:
+        // ANDROID_MIN_SDK_VERSION
+        // ANDROID_TARGET_SDK_VERSION
         minSdkVersion qtMinSdkVersion
         targetSdkVersion qtTargetSdkVersion
         ndk.abiFilters = qtTargetAbiList.split(",")
+    }
+
+    buildTypes {
+        release {
+            // Reduce app size with R8/proguard
+            minifyEnabled true
+            // Remove unused resources
+            shrinkResources true
+            ndk {
+                // Debugging symbols
+                debugSymbolLevel "SYMBOL_TABLE"
+            }
+        }
     }
 }

--- a/tablet_qt/android/build.gradle
+++ b/tablet_qt/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
     }
 }
 
@@ -33,6 +33,8 @@ android {
      * updated by QtCreator and androiddeployqt tools.
      * Changing them manually might break the compilation!
      *******************************************************/
+
+    namespace "org.camcops.camcops"
 
     compileSdkVersion androidCompileSdkVersion
     buildToolsVersion androidBuildToolsVersion

--- a/tablet_qt/camcops.pro
+++ b/tablet_qt/camcops.pro
@@ -311,6 +311,9 @@ android {
     CAMCOPS_32_BIT_VERSION_CODE = "51"
     CAMCOPS_64_BIT_VERSION_CODE = "52"
 
+    ANDROID_MIN_SDK_VERSION = "23"
+    ANDROID_TARGET_SDK_VERSION = "34"
+
     contains(ANDROID_TARGET_ARCH, x86) {
         ANDROID_VERSION_CODE = $${CAMCOPS_32_BIT_VERSION_CODE}
         message("Building for Android/x86_32 (e.g. Android emulator)")

--- a/tools/release_new_version.py
+++ b/tools/release_new_version.py
@@ -718,8 +718,9 @@ class VersionReleaser:
                 version_code_string=version_code_string,
                 version_name=self.new_client_version,
                 release_date_string=self.release_date.strftime("%Y-%m-%d"),
+                # TODO: Read from camcops.pro
                 minimum_android_api=23,
-                target_android_api=34,  # As of 2024-08-31
+                target_android_api=34,  # As of 2025-08-31
             )
 
         self.errors.append(


### PR DESCRIPTION
See #129 and #398.

> Your app currently targets API level 33 and must target at least API level 34 to ensure that it is built on the latest APIs 
> optimised for security and performance. [Learn more](https://developer.android.com/google/play/requirements/target-sdk)

The target API level was not set so defaulted to whatever was set in Qt Creator. This meant that CamCOPS v2.4.22 targeted API level 33 where as the previous version targeted 34. I think by setting it in the `camcops.pro` file this should override everything else but as the numbers get copied around to so many places during the build process it's difficult to be 100% sure.

>This APK results in unused code and resources being sent to users. Your app could be smaller if you used the Android 
> App Bundle. By not optimising your app for device configurations, your app is larger to download and install on users' 
> devices than it needs to be. Larger apps see lower installation success rates and take up storage on users' devices.

This is an advanced build setting in Qt Creator, which annoyingly doesn't get remembered when the application is closed. Medium term plan is to modify the `release_new_version.py` script to build the application bundle without the need for Qt Creator.

> There is no deobfuscation file associated with this APK. If you use obfuscated code (R8/proguard), uploading a 
> deobfuscation file will make crashes and ANRs easier to analyse and debug. Using R8/proguard can help reduce app 
> size. [Learn more](https://developer.android.com/studio/build/shrink-code#decode-stack-trace)

I've set this explicitly in `build.gradle`, though it may well have been happening by default and we just needed to upload the zip file containing the debug symbols to the Play Store. It may well be that the bundle takes care of this as well.

> This APK contains native code, and you've not uploaded debug symbols. We recommend that you upload a symbol file to 
> make your crashes and ANRs easier to analyse and debug.

Is this the same as above?
