### PR TITLE
Update release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
               run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
             - name: Create tar file
               run: |
-                set -eux -o pipefail
+                set -euo pipefail
                 cd ${GITHUB_WORKSPACE}
                 git archive --format=tar.gz -o /tmp/camcops_server.tar.gz --prefix=camcops/ ${{ steps.vars.outputs.tag }}
             - name: Create DEB and RPM packages
-              run:
+              run: |
                 set -euo pipefail
                 ${GITHUB_WORKSPACE}/.github/scripts/python_setup.sh
                 ${GITHUB_WORKSPACE}/.github/scripts/build_packages.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
               uses: actions/checkout@v4
             - name: Work out tag
               id: vars
-              run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+              run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
             - name: Create tar file
               run: |
                 set -euo pipefail

--- a/docs/source/developer/releasing.rst
+++ b/docs/source/developer/releasing.rst
@@ -36,7 +36,7 @@ versions of the CamCOPS client, the script needs to be run on:
 * Windows (for Windows 32/64-bit Windows builds)
 * MacOS (for MacOS and iOS builds)
 
-The builds are created under ``tablet_qt/build\<version>/qt_<qt_version>_<platform>``
+The builds are created under ``tablet_qt/build/<version>/qt_<qt_version>_<platform>``
 
 When a git tag with a new release version number (e.g. v2.4.23) is pushed to
 GitHub, an automated workflow will create the new release with the server DEB

--- a/tools/release_new_version.py
+++ b/tools/release_new_version.py
@@ -1027,6 +1027,14 @@ class VersionReleaser:
         self.upload_to_pypi()
 
     def make_linux_packages(self) -> None:
+        # This step isn't strictly necessary because the GitHub release action
+        # currently does this automatically when the new version tag is pushed.
+        # However if the release action fails for any reason (by putting
+        # [no ci] in the last commit message for example) then it's useful just
+        # to be able to upload the packages to GitHub from here. Given that all
+        # the client builds and the push to PyPI are also happening here, it
+        # would probably make sense to create the packages here as well and
+        # not do them from GitHub release action.
         if self.linux_packages_exist():
             print("Linux packages already built.")
             return
@@ -1512,7 +1520,7 @@ def main() -> None:
     / Distribute the server packages to PyPI
     / Use GitHub release action to create the server packages on GitHub
 
-    - Build the client (depending on the platform)
+    / Build the client (depending on the platform)
     - Distribute to Play Store / Apple Store / GitHub
 
     Ideally we want to do all the checks before tagging and building so we


### PR DESCRIPTION
* Update the documentation on creating a new release to include running the release script.
* Fix the release workflow to build the Linux packages and avoid the deprecation warnings. It won't get tested until we push another tag to the repository.