### PR TITLE
Better handling of incomplete patient registration due to firewall blocking genuine requests

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4020,3 +4020,7 @@ Current C++/SQLite client, Python/SQLAlchemy server
   https://github.com/ucam-department-of-psychiatry/camcops/issues/415
 
 - **Minimum Python version now Python 3.10.**. Python 3.9 has reached end-of-life.
+
+- Fix bug where it was not possible for a single user to upload tasks because of
+  an incomplete patient registration.
+  https://github.com/ucam-department-of-psychiatry/camcops/issues/367

--- a/server/camcops_server/cc_modules/cc_client_api_core.py
+++ b/server/camcops_server/cc_modules/cc_client_api_core.py
@@ -197,6 +197,14 @@ class ServerErrorException(Exception):
     pass
 
 
+class ForbiddenErrorException(Exception):
+    """
+    Exception class for testing an erratic firewall.
+    """
+
+    pass
+
+
 # =============================================================================
 # Return message functions
 # =============================================================================
@@ -255,6 +263,15 @@ def fail_server_error_from_exception(e: Exception) -> NoReturn:
     the specified exception.
     """
     fail_server_error(exception_description(e))
+
+
+def fail_forbidden_error(msg: str) -> NoReturn:
+    """
+    Test function to simulate an erratic firewall.
+
+    Raises :exc:`ForbiddenErrorException`.
+    """
+    raise ForbiddenErrorException(msg)
 
 
 def fail_unsupported_operation(operation: str) -> NoReturn:

--- a/server/camcops_server/cc_modules/client_api.py
+++ b/server/camcops_server/cc_modules/client_api.py
@@ -386,6 +386,7 @@ from camcops_server.cc_modules.cc_client_api_core import (
     fail_server_error,
     fail_unsupported_operation,
     fail_user_error,
+    ForbiddenErrorException,
     get_server_live_records,
     require_keys,
     ServerErrorException,
@@ -3443,6 +3444,14 @@ def client_api(req: "CamcopsRequest") -> Response:
             TabletParam.ERROR: escape_newlines(str(e)),
         }
         status = "503 Database Unavailable: " + str(e)
+
+    except ForbiddenErrorException as e:
+        log.error("Forbidden: {}", e)
+        resultdict = {
+            TabletParam.SUCCESS: FAILURE_CODE,
+            TabletParam.ERROR: escape_newlines(str(e)),
+        }
+        status = "403 Forbidden: " + str(e)
 
     except Exception as e:
         # All other exceptions. May include database write failures.

--- a/server/setup.py
+++ b/server/setup.py
@@ -155,7 +155,7 @@ INSTALL_REQUIRES = [
     "pyparsing==2.4.7",
     "pypdf==6.4.0",  # Used by cardinal_pythonlib.pdf
     "python-dateutil==2.9.0.post0",  # date/time extensions.
-    "sqlparse==0.5.0",
+    "sqlparse==0.5.4",
     # extra
     "py-bcrypt==0.4",  # used by cardinal_pythonlib.crypto
     # -------------------------------------------------------------------------

--- a/server/setup.py
+++ b/server/setup.py
@@ -153,7 +153,7 @@ INSTALL_REQUIRES = [
     "prettytable==0.7.2",
     "psutil==6.1.1",  # process management, cardinal_pythonlib dependency, not currently used  # noqa: E501
     "pyparsing==2.4.7",
-    "pypdf==6.4.0",  # Used by cardinal_pythonlib.pdf
+    "pypdf==6.6.0",  # Used by cardinal_pythonlib.pdf
     "python-dateutil==2.9.0.post0",  # date/time extensions.
     "sqlparse==0.5.4",
     # extra

--- a/server/setup.py
+++ b/server/setup.py
@@ -118,7 +118,7 @@ INSTALL_REQUIRES = [
     "sqlalchemy==2.0.39",  # database access
     "statsmodels==0.14.4",  # e.g. logistic regression
     "twilio==7.9.3",  # SMS backend for Multi-factor authentication
-    "urllib3==2.6.0",  # requests dependency
+    "urllib3==2.6.3",  # requests dependency
     "Wand==0.6.1",  # ImageMagick binding
     # -------------------------------------------------------------------------
     # Not installed here

--- a/server/setup.py
+++ b/server/setup.py
@@ -153,7 +153,7 @@ INSTALL_REQUIRES = [
     "prettytable==0.7.2",
     "psutil==6.1.1",  # process management, cardinal_pythonlib dependency, not currently used  # noqa: E501
     "pyparsing==2.4.7",
-    "pypdf==6.1.3",  # Used by cardinal_pythonlib.pdf
+    "pypdf==6.4.0",  # Used by cardinal_pythonlib.pdf
     "python-dateutil==2.9.0.post0",  # date/time extensions.
     "sqlparse==0.5.0",
     # extra

--- a/server/setup.py
+++ b/server/setup.py
@@ -118,7 +118,7 @@ INSTALL_REQUIRES = [
     "sqlalchemy==2.0.39",  # database access
     "statsmodels==0.14.4",  # e.g. logistic regression
     "twilio==7.9.3",  # SMS backend for Multi-factor authentication
-    "urllib3==2.5.0",  # requests dependency
+    "urllib3==2.6.0",  # requests dependency
     "Wand==0.6.1",  # ImageMagick binding
     # -------------------------------------------------------------------------
     # Not installed here

--- a/tablet_qt/core/camcopsapp.cpp
+++ b/tablet_qt/core/camcopsapp.cpp
@@ -544,10 +544,11 @@ void CamcopsApp::tidyUpFailedRegistration()
 {
     // An erratic firewall that rejects some genuine requests and allows others
     // can result in broken registrations unless we tidy up properly. If
-    // registering the patient succeeds but registering the device fails, unless
-    // we delete the partly registered patient, we will end up with multiple
-    // patients in the database with the same ID and we won't be able to submit
-    // tasks. We're in single user mode so simplest just to delete all patients.
+    // registering the patient succeeds but registering the device fails,
+    // unless we delete the partly registered patient, we will end up with
+    // multiple patients in the database with the same ID and we won't be able
+    // to submit tasks. We're in single user mode so simplest just to delete
+    // all patients.
     m_datadb->deleteFrom(Patient::TABLENAME);
 }
 

--- a/tablet_qt/core/camcopsapp.cpp
+++ b/tablet_qt/core/camcopsapp.cpp
@@ -501,6 +501,8 @@ void CamcopsApp::patientRegistrationFailed(
     const NetworkManager::ErrorCode error_code, const QString& error_string
 )
 {
+    tidyUpFailedRegistration();
+
     deleteNetworkGuiGuard();
 
     const QString base_message
@@ -536,6 +538,17 @@ void CamcopsApp::patientRegistrationFailed(
     maybeRetryNetworkOperation(
         base_message, additional_message, NetworkOperation::RegisterPatient
     );
+}
+
+void CamcopsApp::tidyUpFailedRegistration()
+{
+    // An erratic firewall that rejects some genuine requests and allows others
+    // can result in broken registrations unless we tidy up properly. If
+    // registering the patient succeeds but registering the device fails, unless
+    // we delete the partly registered patient, we will end up with multiple
+    // patients in the database with the same ID and we won't be able to submit
+    // tasks. We're in single user mode so simplest just to delete all patients.
+    m_datadb->deleteFrom(Patient::TABLENAME);
 }
 
 void CamcopsApp::patientRegistrationFinished()

--- a/tablet_qt/core/camcopsapp.h
+++ b/tablet_qt/core/camcopsapp.h
@@ -615,6 +615,9 @@ protected:
 
     QString defaultUserAgent() const;
 
+private:
+    void tidyUpFailedRegistration();
+
 signals:
     // Signal that the "needs upload" state has changed.
     void needsUploadChanged(bool needs_upload);


### PR DESCRIPTION
Fixes #367 

When patient registration fails, delete any partially registered patients from the client database. Before this change a second patient record would be created the next time the patient registered.

The changes on the server are just for debugging. It may be useful to simulate a Forbidden response code if we encounter similar problems in the future.

Also includes another round of security fixes.
