### PR TITLE
Update Qt to latest open souce patch release (6.5.9-lts-lgpl)

### DIFF
--- a/.github/scripts/qt_untagged_release_id.txt
+++ b/.github/scripts/qt_untagged_release_id.txt
@@ -1,1 +1,1 @@
-untagged-bb99ee1e6072aefc5371
+untagged-d427958d312bd8819e3a

--- a/.github/scripts/qt_untagged_release_id.txt
+++ b/.github/scripts/qt_untagged_release_id.txt
@@ -1,1 +1,1 @@
-untagged-94e4361935d72fb30781
+untagged-bb99ee1e6072aefc5371

--- a/.github/scripts/qt_untagged_release_id.txt
+++ b/.github/scripts/qt_untagged_release_id.txt
@@ -1,1 +1,1 @@
-untagged-d427958d312bd8819e3a
+untagged-a1d6b21e1169a50c3d48

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -11,6 +11,7 @@ on:
             - .github/scripts/add_apt_sources.sh
             - .github/scripts/change_apt_mirror.sh
             - .github/scripts/build_client.sh
+            - .github/scripts/qt_untagged_release_id.txt
             - .github/workflows/build-client.yml
 jobs:
     build-client:

--- a/.github/workflows/build-qt.yml
+++ b/.github/workflows/build-qt.yml
@@ -8,7 +8,9 @@ on:
         paths:
             - tablet_qt/tools/build_qt.py
             - tablet_qy/tools/patches/**.patch
-            - tablet_qt/versions/qt_version.txt
+            - tablet_qt/versions/eigen.txt
+            - tablet_qt/versions/openssl.txt
+            - tablet_qt/versions/qt.txt
             - .github/scripts/change_apt_mirror.sh
             - .github/scripts/free_up_disk_space.sh
             - .github/scripts/install_msys_packages.ps1

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -11,6 +11,7 @@ on:
             - .github/scripts/change_apt_mirror.sh
             - .github/scripts/cpp_tests.sh
             - .github/scripts/python_setup.sh
+            - .github/scripts/qt_untagged_release_id.txt
             - .github/workflows/cpp-tests.yml
             - tablet_qt/versions/qt_version.txt
             - tablet_qt/tools/build_qt.py

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4039,3 +4039,5 @@ Current C++/SQLite client, Python/SQLAlchemy server
 
 - Replace wkhtmltopdf and PDFKit, neither of which are maintained with Weasyprint.
   https://github.com/ucam-department-of-psychiatry/camcops/issues/383
+
+- Qt version now 6.5.9.

--- a/tablet_qt/tools/patches/qtmultimedia/find_ffmpeg.patch
+++ b/tablet_qt/tools/patches/qtmultimedia/find_ffmpeg.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/FindFFmpeg.cmake b/cmake/FindFFmpeg.cmake
-index 86be24dd7..68af3afba 100644
+index 2c581442b..d7b52b674 100644
 --- a/cmake/FindFFmpeg.cmake
 +++ b/cmake/FindFFmpeg.cmake
 @@ -208,7 +208,7 @@ foreach (_component ${FFmpeg_FIND_COMPONENTS})

--- a/tablet_qt/versions/qt.txt
+++ b/tablet_qt/versions/qt.txt
@@ -1,1 +1,1 @@
-v6.5.8-lts-lgpl
+v6.5.9-lts-lgpl

--- a/tablet_qt/versions/qt.txt
+++ b/tablet_qt/versions/qt.txt
@@ -1,1 +1,1 @@
-v6.5.6-lts-lgpl
+v6.5.7-lts-lgpl

--- a/tablet_qt/versions/qt.txt
+++ b/tablet_qt/versions/qt.txt
@@ -1,1 +1,1 @@
-v6.5.7-lts-lgpl
+v6.5.8-lts-lgpl


### PR DESCRIPTION
I am not aware of any CamCOPS issues that this release fixes. I'll test it more thoroughly when developing the next batch of tasks. Standard support has ended for Qt6.5.x, though we should still see delayed patch releases pushed to GitHub over time. 

The current LTS version is 6.8.x, which has fixes for at least one of the build problems we are currently patching so we should move to that before too long.
