### PR TITLE
Update SQL Cipher to v4.18.0 (SQLite 3.53.4)

### DIFF
--- a/.github/workflows/python-package-checks.yml
+++ b/.github/workflows/python-package-checks.yml
@@ -37,12 +37,8 @@ jobs:
                   python -m pip install safety "marshmallow<4.0.0" typer==0.16.1
                   echo checking packages for vulnerabilities
                   # All of these vulnerabilities look either harmless or very low risk
-                  # 52495 setuptools. Fix in 65.5.1. We'll be careful not to
-                  #       install malicious packages.
-                  # 67599 pip. Disputed and only relevant if using --extra-index-url,
-                  #       which we're not.
-                  # 70612 jinja2. The maintainer and multiple third parties
-                  #       believe that this vulnerability isn't valid because
-                  #       users shouldn't use untrusted templates without
-                  #       sandboxing.
-                  safety check --full-report --ignore=52495 --ignore=67599 --ignore=70612
+                  # SFTY-20260721-58460 setuptools. CVE-2026-59890. Fixed in 83.0.0. Relevant to macOS APFS
+                  #                     and HFS+ filesystems. We can't upgrade until Pyramid removes its
+                  #                     dependency on pkg_resources (https://github.com/Pylons/pyramid/issues/3731).
+                  #                     Nearly complete as of 2026-08-28.
+                  safety check --full-report --ignore=SFTY-20260721-58460

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4041,3 +4041,5 @@ Current C++/SQLite client, Python/SQLAlchemy server
   https://github.com/ucam-department-of-psychiatry/camcops/issues/383
 
 - Qt version now 6.5.9.
+
+- SQL Cipher version is now v4.18.0, based on SQLite 3.53.4

--- a/docs/source/developer/versions.rst
+++ b/docs/source/developer/versions.rst
@@ -53,5 +53,5 @@ Versions of software etc. used by CamCOPS
 | SQLAlchemy     | 2.0     | No scheduled date. 2.1 is still in development.   |
 |                |         | https://www.sqlalchemy.org/download.html          |
 +----------------+---------+---------------------------------------------------+
-| SQL Cipher     | 4.6.1   | ?; based on SQLite 3.46.1                         |
+| SQL Cipher     | 4.7.0   | ?; based on SQLite 3.49.1                         |
 +----------------+---------+---------------------------------------------------+

--- a/docs/source/developer/versions.rst
+++ b/docs/source/developer/versions.rst
@@ -53,5 +53,5 @@ Versions of software etc. used by CamCOPS
 | SQLAlchemy     | 2.0     | No scheduled date. 2.1 is still in development.   |
 |                |         | https://www.sqlalchemy.org/download.html          |
 +----------------+---------+---------------------------------------------------+
-| SQL Cipher     | 4.5.5   | ?; based on SQLite 3.42.0                         |
+| SQL Cipher     | 4.6.1   | ?; based on SQLite 3.46.1                         |
 +----------------+---------+---------------------------------------------------+

--- a/docs/source/developer/versions.rst
+++ b/docs/source/developer/versions.rst
@@ -47,11 +47,10 @@ Versions of software etc. used by CamCOPS
 +----------------+---------+---------------------------------------------------+
 | Qt             | 6.5.x   | 2026-03-31 (LTS) but 6.5.x branch now             |
 |                |         | commercial-only with delayed open source release. |
-|                |         | Latest non-commercial, non-LTS release is 6.6.    |
 |                |         | https://endoflife.date/qt                         |
 +----------------+---------+---------------------------------------------------+
 | SQLAlchemy     | 2.0     | No scheduled date. 2.1 is still in development.   |
 |                |         | https://www.sqlalchemy.org/download.html          |
 +----------------+---------+---------------------------------------------------+
-| SQL Cipher     | 4.7.0   | ?; based on SQLite 3.49.1                         |
+| SQL Cipher     | 4.18.0  | ?; based on SQLite 3.53.4                         |
 +----------------+---------+---------------------------------------------------+

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -571,7 +571,7 @@ OPENSSL_SRC_URL = (
 
 SQLCIPHER_GIT_URL = "https://github.com/sqlcipher/sqlcipher.git"
 # Branch, tag or commit ID (long) to check out when cloning SQLCipher
-SQLCIPHER_GIT_COMMIT = "v4.7.0"
+SQLCIPHER_GIT_COMMIT = "v4.18.0"
 
 # Eigen
 with open(join(VERSIONS_DIR, "eigen.txt")) as f:

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -571,7 +571,7 @@ OPENSSL_SRC_URL = (
 
 SQLCIPHER_GIT_URL = "https://github.com/sqlcipher/sqlcipher.git"
 # Branch, tag or commit ID (long) to check out when cloning SQLCipher
-SQLCIPHER_GIT_COMMIT = "v4.6.1"
+SQLCIPHER_GIT_COMMIT = "v4.7.0"
 
 # Eigen
 with open(join(VERSIONS_DIR, "eigen.txt")) as f:
@@ -3872,7 +3872,7 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
     target_h = join(destdir, "sqlite3.h")
     target_c = join(destdir, "sqlite3.c")
     target_o = join(destdir, "sqlite3" + target_platform.obj_ext)
-    target_exe = join(destdir, "sqlcipher")  # not always wanted
+    target_exe = join(destdir, "sqlite3")  # not always wanted
 
     want_exe = not target_platform.mobile and not BUILD_PLATFORM.windows
 
@@ -3957,6 +3957,8 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
         cflags = [
             "-DSQLITE_HAS_CODEC",
             f"-I{openssl_include_dir}",
+            "-DSQLITE_EXTRA_INIT=sqlcipher_extra_init",
+            "-DSQLITE_EXTRA_SHUTDOWN=sqlcipher_extra_shutdown",
             # ... sqlite.c does e.g. "#include <openssl/rand.h>"
         ]
         if target_platform.android and USE_CLANG_NOT_GCC_FOR_ANDROID_ARM:
@@ -4024,15 +4026,17 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
         config_args = []  # type: List[str]
         config_args += [
             join(destdir, "configure"),
-            "--enable-tempstore=yes",  # see README.md; equivalent to SQLITE_TEMP_STORE=2  # noqa
+            "--with-tempstore=yes",  # see README.md; equivalent to SQLITE_TEMP_STORE=2  # noqa
             # no quotes (they're fine on the command line but not here):
             f'CFLAGS={" ".join(cflags + gccflags)}',
             f'LDFLAGS={" ".join(ldflags)}',
         ]
         if link_openssl_statically:
-            config_args.append("--with-crypto-lib=none")
             config_args.append("--disable-shared")
-            config_args.append("--enable-static=yes")
+            config_args.append("--enable-static")
+        else:
+            config_args.append("--enable-shared")
+            config_args.append("--disable-static")
 
         # By default, SQLCipher compiles with "-O2" optimizations under gcc;
         # see its "configure" script.
@@ -4060,17 +4064,15 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
             # Cygwin).
             require(MAKE)
             require(TCLSH)
-            if not isfile(target_c) or not isfile(target_h):
-                # Under Windows, if we were to use cl rather than gcc, e.g. by
-                # setting env["CC"], it fails because the make environment uses
-                # Unix-style paths. So we let it use gcc.
-                run([MAKE, "sqlite3.c"], env)  # the amalgamation target
-            if not isfile(target_exe) or not isfile(target_o):
-                run(
-                    [MAKE, "sqlite3" + target_platform.obj_ext], env
-                )  # for static linking
-            if want_exe and not isfile(target_exe):
-                run([MAKE, "sqlcipher"], env)  # the command-line executable
+            # Build amalgamation
+            run([MAKE, "sqlite3.c"], env)
+
+            # Build object from amalgamation
+            run(
+                [MAKE, "sqlite3" + target_platform.obj_ext], env
+            )  # for static linking
+            if want_exe:
+                run([MAKE, "sqlite3"], env)  # the command-line executable
 
         # -------------------------------------------------------------------------
         # SQLCipher/Unix: Check and report
@@ -4083,7 +4085,7 @@ def build_sqlcipher(cfg: Config, target_platform: Platform) -> None:
         f"- {target_h}\n"
         f"and the library:\n"
         f"- {target_o}\n"
-        f"and, on non-mobile platforms, the executable:\n"
+        f"and, on non-mobile platforms, the SQLite/SQLCipher CLI:\n"
         f"- {target_exe}"
     )
 

--- a/tablet_qt/tools/build_qt.py
+++ b/tablet_qt/tools/build_qt.py
@@ -570,7 +570,8 @@ OPENSSL_SRC_URL = (
 # SQLCipher; https://www.zetetic.net/sqlcipher/open-source/
 
 SQLCIPHER_GIT_URL = "https://github.com/sqlcipher/sqlcipher.git"
-SQLCIPHER_GIT_COMMIT = "7c460791eba939e6c6872825219a6644ca47283b"
+# Branch, tag or commit ID (long) to check out when cloning SQLCipher
+SQLCIPHER_GIT_COMMIT = "v4.6.1"
 
 # Eigen
 with open(join(VERSIONS_DIR, "eigen.txt")) as f:
@@ -3828,6 +3829,7 @@ def fetch_sqlcipher(cfg: Config) -> None:
     git_clone(
         prettyname="SQLCipher",
         url=cfg.sqlcipher_git_url,
+        branch=cfg.sqlcipher_git_commit,
         directory=cfg.sqlcipher_src_gitdir,
         # We must have LF endings, not CR+LF, because we're going to use Unix
         # tools even under Windows.


### PR DESCRIPTION
This brings SQL Cipher up to the latest version (v4.18.0) and incorporates a number of security fixes. The build system changed in v4.7.0 and I've updated the `build_qt.py` script to reflect this.

I've tested that the build works on Windows, Linux and Android. I'll test the other platforms along with the forthcoming FFmpeg upgrade and the new tasks before the next release.

Safety is currently ignoring setuptools, which is pinned until Pyramid remove their dependency on `pkg_resources`.
